### PR TITLE
Maven

### DIFF
--- a/dependencies/unpacker.go
+++ b/dependencies/unpacker.go
@@ -15,6 +15,7 @@ import (
 
 	api "github.com/carabiner-dev/unpack/api/v1"
 	"github.com/carabiner-dev/unpack/source/golang"
+	"github.com/carabiner-dev/unpack/source/maven"
 	"github.com/carabiner-dev/unpack/source/npm"
 	"github.com/carabiner-dev/unpack/source/rust"
 )
@@ -29,6 +30,7 @@ func NewUnpacker() *Unpacker {
 			"rust":   rust.New(),
 			"golang": golang.New(),
 			"npm":    npm.New(),
+			"maven":  maven.New(),
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/carabiner-dev/hasher v0.2.3
 	github.com/carabiner-dev/protograph v0.0.0-20260117204235-4dc9de9c0db5
 	github.com/carabiner-dev/signer v0.4.3
+	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.17.2
 	github.com/google/uuid v1.6.0
 	github.com/in-toto/attestation v1.2.0
@@ -29,6 +30,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/avast/retry-go/v4 v4.7.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/carabiner-dev/openeox v0.0.0-20260302211234-88fe8a305401 // indirect
@@ -49,7 +51,6 @@ require (
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
+github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=

--- a/source/maven/decomposer.go
+++ b/source/maven/decomposer.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/protobom/protobom/pkg/sbom"
+
+	api "github.com/carabiner-dev/unpack/api/v1"
+	"github.com/carabiner-dev/unpack/code"
+)
+
+var _ api.Decomposer = (*Decomposer)(nil)
+
+// New returns a new Maven decomposer.
+func New() *Decomposer {
+	return &Decomposer{}
+}
+
+// Decomposer extracts dependency data from Maven projects.
+type Decomposer struct{}
+
+// Options configures the Maven dependency extraction.
+type Options struct {
+	RepoURL         string // Maven repository URL (default: https://repo1.maven.org/maven2)
+	Concurrency     int    // Number of parallel HTTP requests (default: 10)
+	IncludeTest     bool   // Include test-scoped dependencies (default: false)
+	IncludeProvided bool   // Include provided-scoped dependencies (default: false)
+	IncludeOptional bool   // Include optional dependencies (default: false)
+}
+
+var defaultOptions = Options{
+	RepoURL:     defaultRepoURL,
+	Concurrency: defaultConcurrency,
+}
+
+// DefaultOptions returns the default options for the Maven decomposer.
+func (d *Decomposer) DefaultOptions() any {
+	return defaultOptions
+}
+
+// Requirements returns external tool requirements.
+// The Maven decomposer requires no external binaries.
+func (d *Decomposer) Requirements(_ *api.DecomposerOptions) []api.Requirement {
+	return nil
+}
+
+// Extract parses the local pom.xml, resolves dependencies from Maven Central,
+// and builds the complete dependency graph as a protobom NodeList.
+func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error) {
+	dOpts := d.getOptions(opts)
+
+	// 1. Parse local pom.xml
+	pom, err := ParsePomXML(opts.WorkDir)
+	if err != nil {
+		return nil, fmt.Errorf("parsing pom.xml: %w", err)
+	}
+
+	// 2. Create resolver for fetching remote POMs
+	resolver := NewResolver(dOpts)
+
+	// 3. Resolve effective POM (parent chain + BOM imports + interpolation)
+	effective, err := resolver.ResolveEffectivePOM(pom)
+	if err != nil {
+		return nil, fmt.Errorf("resolving effective POM: %w", err)
+	}
+
+	// 4. Build dependency tree
+	dt := NewDependencyTree(effective, resolver, dOpts)
+	if err := dt.Build(); err != nil {
+		return nil, fmt.Errorf("building dependency tree: %w", err)
+	}
+
+	// 5. Convert to NodeList
+	nl, err := dt.ToNodeList(opts)
+	if err != nil {
+		return nil, fmt.Errorf("converting to nodelist: %w", err)
+	}
+
+	return nl, nil
+}
+
+// FindCodeBases locates directories containing pom.xml files.
+func (d *Decomposer) FindCodeBases(index *code.PathIndex) ([]string, error) {
+	return index.FindFileLocations("pom.xml")
+}
+
+// getOptions extracts Maven-specific options from DecomposerOptions.
+func (d *Decomposer) getOptions(opts *api.DecomposerOptions) *Options {
+	if opts != nil {
+		if dOpts, ok := opts.GetDriverOptions(d).(*Options); ok {
+			return dOpts
+		}
+	}
+	return &defaultOptions
+}
+
+// CanDecompose checks if a directory contains a Maven project.
+func CanDecompose(dir string) bool {
+	_, err := ParsePomXML(filepath.Clean(dir))
+	return err == nil
+}

--- a/source/maven/decomposer_test.go
+++ b/source/maven/decomposer_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	api "github.com/carabiner-dev/unpack/api/v1"
+)
+
+// failingAgentImpl returns 404 for all requests instantly (no retries needed).
+type failingAgentImpl struct{}
+
+func (f *failingAgentImpl) SendGetRequest(_ *http.Client, url string) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, fmt.Errorf("not found: %s", url)
+}
+
+func (f *failingAgentImpl) SendPostRequest(_ *http.Client, _ string, _ []byte, _ string) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *failingAgentImpl) SendHeadRequest(_ *http.Client, _ string) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestDecomposerDefaultOptions(t *testing.T) {
+	t.Parallel()
+	d := New()
+	opts := d.DefaultOptions()
+	require.IsType(t, Options{}, opts)
+
+	o, ok := opts.(Options)
+	require.True(t, ok)
+	require.Equal(t, defaultRepoURL, o.RepoURL)
+	require.Equal(t, defaultConcurrency, o.Concurrency)
+}
+
+func TestDecomposerRequirements(t *testing.T) {
+	t.Parallel()
+	d := New()
+	require.Nil(t, d.Requirements(nil))
+}
+
+func TestDecomposerExtractSimple(t *testing.T) {
+	t.Parallel()
+
+	// Parse and extract with a resolver that fails all remote fetches.
+	// This tests that local pom.xml parsing and tree building works
+	// even when remote resolution isn't available.
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	resolver := NewResolver(&Options{RepoURL: "https://unused.test", Concurrency: 1})
+	resolver.Agent = resolver.Agent.WithRetries(0)
+	resolver.Agent.SetImplementation(&failingAgentImpl{})
+
+	effective, err := resolver.ResolveEffectivePOM(pom)
+	require.NoError(t, err)
+
+	dt := NewDependencyTree(effective, resolver, &defaultOptions)
+	err = dt.Build()
+	require.NoError(t, err)
+
+	opts := &api.DecomposerOptions{WorkDir: "testdata/simple"}
+	nl, err := dt.ToNodeList(opts)
+	require.NoError(t, err)
+	require.NotNil(t, nl)
+
+	// Should have the root node at minimum
+	require.Len(t, nl.GetRootElements(), 1)
+
+	root := nl.GetNodeByID(nl.GetRootElements()[0])
+	require.Equal(t, "simple-app", root.GetName())
+	require.Equal(t, "pkg:maven/com.example/simple-app@1.0.0", root.GetIdentifiers()[int32(1)])
+
+	// Direct compile deps should be resolved (guava, commons-lang3)
+	// Test and provided deps should be excluded by default
+	nodes := nl.GetNodes()
+	require.GreaterOrEqual(t, len(nodes), 3) // root + guava + commons-lang3
+}
+
+func TestCanDecompose(t *testing.T) {
+	t.Parallel()
+	require.True(t, CanDecompose("testdata/simple"))
+	require.False(t, CanDecompose("testdata/nonexistent"))
+}

--- a/source/maven/pom.go
+++ b/source/maven/pom.go
@@ -63,7 +63,7 @@ type Parent struct {
 // Dependency represents a Maven dependency declaration.
 type Dependency struct {
 	GroupID    string      `xml:"groupId"`
-	ArtifactID string     `xml:"artifactId"`
+	ArtifactID string      `xml:"artifactId"`
 	Version    string      `xml:"version"`
 	Scope      string      `xml:"scope"`
 	Type       string      `xml:"type"`
@@ -71,6 +71,15 @@ type Dependency struct {
 	Optional   string      `xml:"optional"`
 	Exclusions []Exclusion `xml:"exclusions>exclusion"`
 }
+
+const (
+	ScopeCompile  = "compile"
+	ScopeRuntime  = "runtime"
+	ScopeTest     = "test"
+	ScopeProvided = "provided"
+	ScopeSystem   = "system"
+	ScopeImport   = "import"
+)
 
 // IsOptional returns true if the dependency is marked optional.
 func (d *Dependency) IsOptional() bool {
@@ -80,7 +89,7 @@ func (d *Dependency) IsOptional() bool {
 // EffectiveScope returns the dependency's scope, defaulting to "compile".
 func (d *Dependency) EffectiveScope() string {
 	if d.Scope == "" {
-		return "compile"
+		return ScopeCompile
 	}
 	return d.Scope
 }

--- a/source/maven/pom.go
+++ b/source/maven/pom.go
@@ -4,10 +4,14 @@
 package maven
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/text/encoding/ianaindex"
 )
 
 // POM represents a Maven POM file.
@@ -179,10 +183,27 @@ func ParsePomXML(dir string) (*POM, error) {
 }
 
 // ParsePomXMLData parses POM content from raw bytes.
+// Handles non-UTF-8 encodings (e.g., ISO-8859-1) commonly found in Maven POMs.
 func ParsePomXMLData(data []byte) (*POM, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.CharsetReader = charsetReader
+
 	var pom POM
-	if err := xml.Unmarshal(data, &pom); err != nil {
+	if err := decoder.Decode(&pom); err != nil {
 		return nil, fmt.Errorf("parsing pom.xml: %w", err)
 	}
 	return &pom, nil
+}
+
+// charsetReader returns a reader that converts from the named charset to UTF-8.
+func charsetReader(charset string, input io.Reader) (io.Reader, error) {
+	enc, err := ianaindex.IANA.Encoding(charset)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported charset %q: %w", charset, err)
+	}
+	if enc == nil {
+		// nil encoding means UTF-8
+		return input, nil
+	}
+	return enc.NewDecoder().Reader(input), nil
 }

--- a/source/maven/pom.go
+++ b/source/maven/pom.go
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// POM represents a Maven POM file.
+type POM struct {
+	XMLName              xml.Name              `xml:"project"`
+	ModelVersion         string                `xml:"modelVersion"`
+	Parent               *Parent               `xml:"parent"`
+	GroupID              string                `xml:"groupId"`
+	ArtifactID           string                `xml:"artifactId"`
+	Version              string                `xml:"version"`
+	Packaging            string                `xml:"packaging"`
+	Name                 string                `xml:"name"`
+	Description          string                `xml:"description"`
+	URL                  string                `xml:"url"`
+	Licenses             []License             `xml:"licenses>license"`
+	Properties           Properties            `xml:"properties"`
+	DependencyManagement *DependencyManagement `xml:"dependencyManagement"`
+	Dependencies         []Dependency          `xml:"dependencies>dependency"`
+	Modules              []string              `xml:"modules>module"`
+	Repositories         []Repository          `xml:"repositories>repository"`
+}
+
+// EffectiveGroupID returns the POM's groupId, falling back to parent's.
+func (p *POM) EffectiveGroupID() string {
+	if p.GroupID != "" {
+		return p.GroupID
+	}
+	if p.Parent != nil {
+		return p.Parent.GroupID
+	}
+	return ""
+}
+
+// EffectiveVersion returns the POM's version, falling back to parent's.
+func (p *POM) EffectiveVersion() string {
+	if p.Version != "" {
+		return p.Version
+	}
+	if p.Parent != nil {
+		return p.Parent.Version
+	}
+	return ""
+}
+
+// Parent represents a POM parent reference.
+type Parent struct {
+	GroupID      string `xml:"groupId"`
+	ArtifactID   string `xml:"artifactId"`
+	Version      string `xml:"version"`
+	RelativePath string `xml:"relativePath"`
+}
+
+// Dependency represents a Maven dependency declaration.
+type Dependency struct {
+	GroupID    string      `xml:"groupId"`
+	ArtifactID string     `xml:"artifactId"`
+	Version    string      `xml:"version"`
+	Scope      string      `xml:"scope"`
+	Type       string      `xml:"type"`
+	Classifier string      `xml:"classifier"`
+	Optional   string      `xml:"optional"`
+	Exclusions []Exclusion `xml:"exclusions>exclusion"`
+}
+
+// IsOptional returns true if the dependency is marked optional.
+func (d *Dependency) IsOptional() bool {
+	return d.Optional == "true"
+}
+
+// EffectiveScope returns the dependency's scope, defaulting to "compile".
+func (d *Dependency) EffectiveScope() string {
+	if d.Scope == "" {
+		return "compile"
+	}
+	return d.Scope
+}
+
+// EffectiveType returns the dependency's type, defaulting to "jar".
+func (d *Dependency) EffectiveType() string {
+	if d.Type == "" {
+		return "jar"
+	}
+	return d.Type
+}
+
+// Key returns "groupId:artifactId" used for mediation lookups.
+func (d *Dependency) Key() string {
+	return d.GroupID + ":" + d.ArtifactID
+}
+
+// Exclusion represents a dependency exclusion.
+type Exclusion struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+}
+
+// Matches returns true if the exclusion matches the given coordinates.
+// Supports wildcard "*" for both groupId and artifactId.
+func (e *Exclusion) Matches(groupID, artifactID string) bool {
+	gMatch := e.GroupID == "*" || e.GroupID == groupID
+	aMatch := e.ArtifactID == "*" || e.ArtifactID == artifactID
+	return gMatch && aMatch
+}
+
+// License represents a license declaration in a POM.
+type License struct {
+	Name         string `xml:"name"`
+	URL          string `xml:"url"`
+	Distribution string `xml:"distribution"`
+	Comments     string `xml:"comments"`
+}
+
+// DependencyManagement holds managed dependency versions and settings.
+type DependencyManagement struct {
+	Dependencies []Dependency `xml:"dependencies>dependency"`
+}
+
+// Repository represents a Maven repository declaration.
+type Repository struct {
+	ID   string `xml:"id"`
+	URL  string `xml:"url"`
+	Name string `xml:"name"`
+}
+
+// Properties is a map of Maven property key-value pairs.
+// It requires custom XML unmarshaling because properties are
+// arbitrary child elements: <jackson.version>2.15</jackson.version>
+type Properties map[string]string
+
+// UnmarshalXML decodes Maven properties from XML.
+func (p *Properties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	*p = Properties{}
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			var value string
+			if err := d.DecodeElement(&value, &t); err != nil {
+				return fmt.Errorf("decoding property %s: %w", t.Name.Local, err)
+			}
+			(*p)[t.Name.Local] = value
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+// ParsePomXML reads and parses a pom.xml file from the given directory.
+func ParsePomXML(dir string) (*POM, error) {
+	pomPath := filepath.Join(dir, "pom.xml")
+	data, err := os.ReadFile(pomPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading pom.xml: %w", err)
+	}
+	return ParsePomXMLData(data)
+}
+
+// ParsePomXMLData parses POM content from raw bytes.
+func ParsePomXMLData(data []byte) (*POM, error) {
+	var pom POM
+	if err := xml.Unmarshal(data, &pom); err != nil {
+		return nil, fmt.Errorf("parsing pom.xml: %w", err)
+	}
+	return &pom, nil
+}

--- a/source/maven/pom_test.go
+++ b/source/maven/pom_test.go
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePomXML(t *testing.T) {
+	t.Parallel()
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	require.Equal(t, "com.example", pom.GroupID)
+	require.Equal(t, "simple-app", pom.ArtifactID)
+	require.Equal(t, "1.0.0", pom.Version)
+	require.Equal(t, "jar", pom.Packaging)
+	require.Equal(t, "Simple Test App", pom.Name)
+}
+
+func TestParsePomXMLDependencies(t *testing.T) {
+	t.Parallel()
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	require.Len(t, pom.Dependencies, 5)
+
+	// Guava with property reference
+	require.Equal(t, "com.google.guava", pom.Dependencies[0].GroupID)
+	require.Equal(t, "guava", pom.Dependencies[0].ArtifactID)
+	require.Equal(t, "${guava.version}", pom.Dependencies[0].Version)
+
+	// commons-lang3
+	require.Equal(t, "org.apache.commons", pom.Dependencies[1].GroupID)
+	require.Equal(t, "${commons.version}", pom.Dependencies[1].Version)
+
+	// junit with test scope
+	require.Equal(t, "junit", pom.Dependencies[2].GroupID)
+	require.Equal(t, "test", pom.Dependencies[2].Scope)
+	require.Equal(t, "test", pom.Dependencies[2].EffectiveScope())
+
+	// servlet-api with provided scope
+	require.Equal(t, "provided", pom.Dependencies[3].EffectiveScope())
+
+	// jsr305 optional
+	require.Equal(t, "true", pom.Dependencies[4].Optional)
+	require.True(t, pom.Dependencies[4].IsOptional())
+}
+
+func TestParsePomXMLProperties(t *testing.T) {
+	t.Parallel()
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	require.Len(t, pom.Properties, 3)
+	require.Equal(t, "33.0.0-jre", pom.Properties["guava.version"])
+	require.Equal(t, "3.14.0", pom.Properties["commons.version"])
+	require.Equal(t, "UTF-8", pom.Properties["project.build.sourceEncoding"])
+}
+
+func TestParsePomXMLLicenses(t *testing.T) {
+	t.Parallel()
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	require.Len(t, pom.Licenses, 1)
+	require.Equal(t, "Apache License, Version 2.0", pom.Licenses[0].Name)
+	require.Equal(t, "https://www.apache.org/licenses/LICENSE-2.0", pom.Licenses[0].URL)
+}
+
+func TestParsePomXMLDependencyManagement(t *testing.T) {
+	t.Parallel()
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	require.NotNil(t, pom.DependencyManagement)
+	require.Len(t, pom.DependencyManagement.Dependencies, 1)
+
+	managed := pom.DependencyManagement.Dependencies[0]
+	require.Equal(t, "com.google.guava", managed.GroupID)
+	require.Equal(t, "guava", managed.ArtifactID)
+	require.Len(t, managed.Exclusions, 1)
+	require.Equal(t, "com.google.code.findbugs", managed.Exclusions[0].GroupID)
+	require.Equal(t, "jsr305", managed.Exclusions[0].ArtifactID)
+}
+
+func TestParsePomXMLData(t *testing.T) {
+	t.Parallel()
+	data := []byte(`<?xml version="1.0"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test.group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>2.0.0</version>
+</project>`)
+
+	pom, err := ParsePomXMLData(data)
+	require.NoError(t, err)
+	require.Equal(t, "test.group", pom.GroupID)
+	require.Equal(t, "test-artifact", pom.ArtifactID)
+	require.Equal(t, "2.0.0", pom.Version)
+}
+
+func TestParsePomXMLDataInvalid(t *testing.T) {
+	t.Parallel()
+	_, err := ParsePomXMLData([]byte("not xml"))
+	require.Error(t, err)
+}
+
+func TestDependencyKey(t *testing.T) {
+	t.Parallel()
+	d := Dependency{GroupID: "com.google.guava", ArtifactID: "guava"}
+	require.Equal(t, "com.google.guava:guava", d.Key())
+}
+
+func TestDependencyDefaults(t *testing.T) {
+	t.Parallel()
+	d := Dependency{}
+	require.Equal(t, "compile", d.EffectiveScope())
+	require.Equal(t, "jar", d.EffectiveType())
+	require.False(t, d.IsOptional())
+}
+
+func TestExclusionMatches(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		excl    Exclusion
+		group   string
+		art     string
+		matches bool
+	}{
+		{"exact", Exclusion{"g", "a"}, "g", "a", true},
+		{"no match", Exclusion{"g", "a"}, "g", "b", false},
+		{"wildcard group", Exclusion{"*", "a"}, "any", "a", true},
+		{"wildcard artifact", Exclusion{"g", "*"}, "g", "any", true},
+		{"wildcard both", Exclusion{"*", "*"}, "any", "any", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.matches, tc.excl.Matches(tc.group, tc.art))
+		})
+	}
+}
+
+func TestEffectiveGroupIDAndVersion(t *testing.T) {
+	t.Parallel()
+
+	// With own values
+	pom := &POM{GroupID: "own.group", Version: "1.0"}
+	require.Equal(t, "own.group", pom.EffectiveGroupID())
+	require.Equal(t, "1.0", pom.EffectiveVersion())
+
+	// Inherit from parent
+	pom = &POM{Parent: &Parent{GroupID: "parent.group", Version: "2.0"}}
+	require.Equal(t, "parent.group", pom.EffectiveGroupID())
+	require.Equal(t, "2.0", pom.EffectiveVersion())
+
+	// Own overrides parent
+	pom = &POM{GroupID: "own.group", Version: "1.0", Parent: &Parent{GroupID: "parent.group", Version: "2.0"}}
+	require.Equal(t, "own.group", pom.EffectiveGroupID())
+	require.Equal(t, "1.0", pom.EffectiveVersion())
+}

--- a/source/maven/properties.go
+++ b/source/maven/properties.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"regexp"
+	"strings"
+)
+
+var propertyPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// maxInterpolationPasses limits recursive property resolution to prevent infinite loops.
+const maxInterpolationPasses = 10
+
+// InterpolatePOM resolves all ${...} property placeholders in a POM.
+// It modifies the POM in place and returns it for convenience.
+func InterpolatePOM(pom *POM) *POM {
+	props := buildPropertyMap(pom)
+
+	// Resolve property-in-property references iteratively
+	props = resolvePropertyRefs(props)
+
+	// Interpolate all string fields
+	pom.GroupID = interpolateString(pom.GroupID, props)
+	pom.ArtifactID = interpolateString(pom.ArtifactID, props)
+	pom.Version = interpolateString(pom.Version, props)
+	pom.Name = interpolateString(pom.Name, props)
+	pom.Description = interpolateString(pom.Description, props)
+	pom.URL = interpolateString(pom.URL, props)
+
+	for i := range pom.Dependencies {
+		interpolateDependency(&pom.Dependencies[i], props)
+	}
+
+	if pom.DependencyManagement != nil {
+		for i := range pom.DependencyManagement.Dependencies {
+			interpolateDependency(&pom.DependencyManagement.Dependencies[i], props)
+		}
+	}
+
+	for i := range pom.Licenses {
+		pom.Licenses[i].Name = interpolateString(pom.Licenses[i].Name, props)
+		pom.Licenses[i].URL = interpolateString(pom.Licenses[i].URL, props)
+	}
+
+	return pom
+}
+
+// interpolateDependency resolves property placeholders in a Dependency.
+func interpolateDependency(dep *Dependency, props map[string]string) {
+	dep.GroupID = interpolateString(dep.GroupID, props)
+	dep.ArtifactID = interpolateString(dep.ArtifactID, props)
+	dep.Version = interpolateString(dep.Version, props)
+	dep.Scope = interpolateString(dep.Scope, props)
+	dep.Type = interpolateString(dep.Type, props)
+	dep.Classifier = interpolateString(dep.Classifier, props)
+	dep.Optional = interpolateString(dep.Optional, props)
+}
+
+// interpolateString replaces ${property.name} tokens in s using the given properties.
+// Unresolvable placeholders are left as-is.
+func interpolateString(s string, props map[string]string) string {
+	if !strings.Contains(s, "${") {
+		return s
+	}
+	return propertyPattern.ReplaceAllStringFunc(s, func(match string) string {
+		key := match[2 : len(match)-1] // strip ${ and }
+		if val, ok := props[key]; ok {
+			return val
+		}
+		return match // leave unresolved
+	})
+}
+
+// buildPropertyMap constructs the full property map for a POM,
+// including implicit project.* properties.
+func buildPropertyMap(pom *POM) map[string]string {
+	props := make(map[string]string)
+
+	// User-defined properties first
+	for k, v := range pom.Properties {
+		props[k] = v
+	}
+
+	// Implicit project properties (these can be overridden by user props)
+	setIfNotEmpty := func(key, val string) {
+		if val != "" {
+			if _, exists := props[key]; !exists {
+				props[key] = val
+			}
+		}
+	}
+
+	setIfNotEmpty("project.groupId", pom.EffectiveGroupID())
+	setIfNotEmpty("project.artifactId", pom.ArtifactID)
+	setIfNotEmpty("project.version", pom.EffectiveVersion())
+	setIfNotEmpty("project.name", pom.Name)
+	setIfNotEmpty("project.description", pom.Description)
+	setIfNotEmpty("project.url", pom.URL)
+	setIfNotEmpty("project.packaging", pom.Packaging)
+
+	// Shorthand aliases
+	setIfNotEmpty("groupId", pom.EffectiveGroupID())
+	setIfNotEmpty("artifactId", pom.ArtifactID)
+	setIfNotEmpty("version", pom.EffectiveVersion())
+
+	if pom.Parent != nil {
+		setIfNotEmpty("project.parent.groupId", pom.Parent.GroupID)
+		setIfNotEmpty("project.parent.artifactId", pom.Parent.ArtifactID)
+		setIfNotEmpty("project.parent.version", pom.Parent.Version)
+	}
+
+	return props
+}
+
+// resolvePropertyRefs iteratively resolves property values that reference
+// other properties (e.g., a.version = ${b.version}). Stops after
+// maxInterpolationPasses or when no more substitutions are made.
+func resolvePropertyRefs(props map[string]string) map[string]string {
+	for range maxInterpolationPasses {
+		changed := false
+		for k, v := range props {
+			if !strings.Contains(v, "${") {
+				continue
+			}
+			resolved := interpolateString(v, props)
+			if resolved != v {
+				props[k] = resolved
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return props
+}

--- a/source/maven/properties_test.go
+++ b/source/maven/properties_test.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpolatePOM(t *testing.T) {
+	t.Parallel()
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	InterpolatePOM(pom)
+
+	// Property references in dependency versions should be resolved
+	require.Equal(t, "33.0.0-jre", pom.Dependencies[0].Version)
+	require.Equal(t, "3.14.0", pom.Dependencies[1].Version)
+
+	// DependencyManagement should also be resolved
+	require.Equal(t, "33.0.0-jre", pom.DependencyManagement.Dependencies[0].Version)
+}
+
+func TestInterpolateProjectProperties(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "my-app",
+		Version:    "3.0.0",
+		Properties: Properties{
+			"my.group": "${project.groupId}",
+		},
+		Dependencies: []Dependency{
+			{GroupID: "${my.group}", ArtifactID: "dep", Version: "${project.version}"},
+		},
+	}
+
+	InterpolatePOM(pom)
+
+	require.Equal(t, "com.example", pom.Dependencies[0].GroupID)
+	require.Equal(t, "3.0.0", pom.Dependencies[0].Version)
+}
+
+func TestInterpolateParentProperties(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		Parent: &Parent{
+			GroupID:    "com.parent",
+			ArtifactID: "parent-pom",
+			Version:    "5.0.0",
+		},
+		ArtifactID: "child",
+		Dependencies: []Dependency{
+			{GroupID: "${project.parent.groupId}", ArtifactID: "dep", Version: "${project.parent.version}"},
+		},
+	}
+
+	InterpolatePOM(pom)
+
+	require.Equal(t, "com.parent", pom.Dependencies[0].GroupID)
+	require.Equal(t, "5.0.0", pom.Dependencies[0].Version)
+}
+
+func TestInterpolateRecursiveProperties(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Properties: Properties{
+			"base.version": "2.0",
+			"full.version": "${base.version}.1",
+		},
+		Dependencies: []Dependency{
+			{GroupID: "g", ArtifactID: "a", Version: "${full.version}"},
+		},
+	}
+
+	InterpolatePOM(pom)
+
+	require.Equal(t, "2.0.1", pom.Dependencies[0].Version)
+}
+
+func TestInterpolateUnresolvable(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{GroupID: "g", ArtifactID: "a", Version: "${unknown.property}"},
+		},
+	}
+
+	InterpolatePOM(pom)
+
+	// Unresolvable properties should be left as-is
+	require.Equal(t, "${unknown.property}", pom.Dependencies[0].Version)
+}
+
+func TestInterpolateString(t *testing.T) {
+	t.Parallel()
+	props := map[string]string{
+		"a": "hello",
+		"b": "world",
+	}
+
+	require.Equal(t, "hello", interpolateString("${a}", props))
+	require.Equal(t, "hello-world", interpolateString("${a}-${b}", props))
+	require.Equal(t, "no-props", interpolateString("no-props", props))
+	require.Equal(t, "${missing}", interpolateString("${missing}", props))
+	require.Empty(t, interpolateString("", props))
+}
+
+func TestInterpolateInheritedGroupAndVersion(t *testing.T) {
+	t.Parallel()
+	// When groupId/version are empty, they should come from parent
+	pom := &POM{
+		Parent: &Parent{
+			GroupID: "com.parent",
+			Version: "1.0.0",
+		},
+		ArtifactID: "child",
+		Dependencies: []Dependency{
+			{GroupID: "g", ArtifactID: "a", Version: "${project.groupId}"},
+		},
+	}
+
+	InterpolatePOM(pom)
+
+	require.Equal(t, "com.parent", pom.Dependencies[0].Version)
+}

--- a/source/maven/resolver.go
+++ b/source/maven/resolver.go
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	khttp "sigs.k8s.io/release-utils/http"
+)
+
+const (
+	defaultRepoURL     = "https://repo1.maven.org/maven2"
+	defaultConcurrency = 10
+	defaultTimeout     = 30 * time.Second
+	maxParentDepth     = 10
+)
+
+// Resolver fetches and caches Maven POMs from remote repositories.
+type Resolver struct {
+	Agent   *khttp.Agent
+	RepoURL string
+	cache   map[string]*POM
+	mu      sync.RWMutex
+}
+
+// NewResolver creates a Resolver with the given options.
+func NewResolver(opts *Options) *Resolver {
+	repoURL := opts.RepoURL
+	if repoURL == "" {
+		repoURL = defaultRepoURL
+	}
+	concurrency := opts.Concurrency
+	if concurrency <= 0 {
+		concurrency = defaultConcurrency
+	}
+
+	agent := khttp.NewAgent().
+		WithTimeout(defaultTimeout).
+		WithMaxParallel(concurrency).
+		WithFailOnHTTPError(true)
+
+	return &Resolver{
+		Agent:   agent,
+		RepoURL: repoURL,
+		cache:   make(map[string]*POM),
+	}
+}
+
+// cacheKey returns the cache lookup key for a coordinate.
+func cacheKey(groupID, artifactID, version string) string {
+	return groupID + ":" + artifactID + ":" + version
+}
+
+// FetchPOM fetches a POM from the repository, parses it, and caches the result.
+func (r *Resolver) FetchPOM(groupID, artifactID, version string) (*POM, error) {
+	key := cacheKey(groupID, artifactID, version)
+
+	r.mu.RLock()
+	if pom, ok := r.cache[key]; ok {
+		r.mu.RUnlock()
+		return pom, nil
+	}
+	r.mu.RUnlock()
+
+	url := r.pomURL(groupID, artifactID, version)
+	data, err := r.Agent.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching POM %s: %w", key, err)
+	}
+
+	pom, err := ParsePomXMLData(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing POM %s: %w", key, err)
+	}
+
+	r.mu.Lock()
+	r.cache[key] = pom
+	r.mu.Unlock()
+
+	return pom, nil
+}
+
+// pomURL constructs the Maven repository URL for a POM file.
+func (r *Resolver) pomURL(groupID, artifactID, version string) string {
+	groupPath := strings.ReplaceAll(groupID, ".", "/")
+	return fmt.Sprintf("%s/%s/%s/%s/%s-%s.pom", r.RepoURL, groupPath, artifactID, version, artifactID, version)
+}
+
+// metadataURL constructs the URL for maven-metadata.xml.
+func (r *Resolver) metadataURL(groupID, artifactID string) string {
+	groupPath := strings.ReplaceAll(groupID, ".", "/")
+	return fmt.Sprintf("%s/%s/%s/maven-metadata.xml", r.RepoURL, groupPath, artifactID)
+}
+
+// mavenMetadata represents the structure of maven-metadata.xml.
+type mavenMetadata struct {
+	GroupID    string   `xml:"groupId"`
+	ArtifactID string   `xml:"artifactId"`
+	Latest     string   `xml:"versioning>latest"`
+	Release    string   `xml:"versioning>release"`
+	Versions   []string `xml:"versioning>versions>version"`
+}
+
+// FetchAvailableVersions fetches maven-metadata.xml and returns all versions.
+func (r *Resolver) FetchAvailableVersions(groupID, artifactID string) ([]string, error) {
+	url := r.metadataURL(groupID, artifactID)
+	data, err := r.Agent.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching metadata for %s:%s: %w", groupID, artifactID, err)
+	}
+
+	var meta mavenMetadata
+	if err := xml.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parsing metadata for %s:%s: %w", groupID, artifactID, err)
+	}
+
+	return meta.Versions, nil
+}
+
+// ResolveVersionRange resolves a version range to a concrete version.
+func (r *Resolver) ResolveVersionRange(groupID, artifactID, rangeSpec string) (string, error) {
+	vr, err := ParseVersionRange(rangeSpec)
+	if err != nil {
+		return "", fmt.Errorf("parsing version range %q: %w", rangeSpec, err)
+	}
+
+	versions, err := r.FetchAvailableVersions(groupID, artifactID)
+	if err != nil {
+		return "", err
+	}
+
+	best := vr.SelectVersion(versions)
+	if best == "" {
+		return "", fmt.Errorf("no version of %s:%s satisfies range %s", groupID, artifactID, rangeSpec)
+	}
+
+	return best, nil
+}
+
+// ResolveEffectivePOM resolves the full parent chain, merges inherited data,
+// processes BOM imports, and interpolates all properties.
+func (r *Resolver) ResolveEffectivePOM(pom *POM) (*POM, error) {
+	// Resolve parent chain
+	resolved, err := r.resolveParentChain(pom, 0)
+	if err != nil {
+		return nil, fmt.Errorf("resolving parent chain: %w", err)
+	}
+
+	// Process BOM imports in dependencyManagement
+	if err := r.resolveBOMImports(resolved, 0); err != nil {
+		return nil, fmt.Errorf("resolving BOM imports: %w", err)
+	}
+
+	// Interpolate all properties
+	InterpolatePOM(resolved)
+
+	return resolved, nil
+}
+
+// resolveParentChain walks up the parent chain and merges each parent into the child.
+func (r *Resolver) resolveParentChain(pom *POM, depth int) (*POM, error) {
+	if depth > maxParentDepth {
+		return nil, fmt.Errorf("parent chain exceeds maximum depth of %d", maxParentDepth)
+	}
+
+	if pom.Parent == nil {
+		return pom, nil
+	}
+
+	parentPOM, err := r.FetchPOM(pom.Parent.GroupID, pom.Parent.ArtifactID, pom.Parent.Version)
+	if err != nil {
+		// Parent resolution failure is non-fatal: return what we have
+		return pom, nil //nolint:nilerr
+	}
+
+	// Recursively resolve the parent's own parents first
+	resolvedParent, err := r.resolveParentChain(parentPOM, depth+1)
+	if err != nil {
+		return pom, nil //nolint:nilerr
+	}
+
+	// Merge parent into child
+	return MergeParent(pom, resolvedParent), nil
+}
+
+// MergeParent merges a parent POM into a child POM.
+// Child values take precedence over parent values.
+func MergeParent(child, parent *POM) *POM {
+	// Inherit groupId and version if not set
+	if child.GroupID == "" {
+		child.GroupID = parent.GroupID
+	}
+	if child.Version == "" {
+		child.Version = parent.Version
+	}
+
+	// Merge properties: parent first, child overrides
+	merged := make(Properties)
+	for k, v := range parent.Properties {
+		merged[k] = v
+	}
+	for k, v := range child.Properties {
+		merged[k] = v
+	}
+	child.Properties = merged
+
+	// Merge dependencyManagement: child entries take precedence
+	if parent.DependencyManagement != nil {
+		if child.DependencyManagement == nil {
+			child.DependencyManagement = &DependencyManagement{}
+		}
+
+		// Build lookup of child's managed deps
+		childManaged := make(map[string]struct{})
+		for i := range child.DependencyManagement.Dependencies {
+			childManaged[child.DependencyManagement.Dependencies[i].Key()] = struct{}{}
+		}
+
+		// Add parent managed deps that child doesn't override
+		for i := range parent.DependencyManagement.Dependencies {
+			d := parent.DependencyManagement.Dependencies[i]
+			if _, exists := childManaged[d.Key()]; !exists {
+				child.DependencyManagement.Dependencies = append(
+					child.DependencyManagement.Dependencies, d,
+				)
+			}
+		}
+	}
+
+	// Inherit licenses if child has none
+	if len(child.Licenses) == 0 {
+		child.Licenses = parent.Licenses
+	}
+
+	// Inherit repositories
+	if len(child.Repositories) == 0 {
+		child.Repositories = parent.Repositories
+	}
+
+	return child
+}
+
+// resolveBOMImports processes dependencyManagement entries with
+// scope=import and type=pom, merging their dependencyManagement
+// into the current POM.
+func (r *Resolver) resolveBOMImports(pom *POM, depth int) error {
+	if depth > maxParentDepth {
+		return fmt.Errorf("BOM import chain exceeds maximum depth of %d", maxParentDepth)
+	}
+
+	if pom.DependencyManagement == nil {
+		return nil
+	}
+
+	// First interpolate so we can resolve BOM coordinates
+	InterpolatePOM(pom)
+
+	var remaining []Dependency
+	var imported []Dependency
+
+	for i := range pom.DependencyManagement.Dependencies {
+		dep := pom.DependencyManagement.Dependencies[i]
+		if dep.Scope == ScopeImport && dep.EffectiveType() == "pom" {
+			bomPOM, err := r.FetchPOM(dep.GroupID, dep.ArtifactID, dep.Version)
+			if err != nil {
+				// Skip unresolvable BOMs
+				continue
+			}
+
+			// Resolve the BOM's own parents and BOMs
+			resolved, err := r.resolveParentChain(bomPOM, 0)
+			if err != nil {
+				continue
+			}
+
+			// Interpolate the BOM
+			InterpolatePOM(resolved)
+
+			// Recursively resolve nested BOM imports
+			if err := r.resolveBOMImports(resolved, depth+1); err != nil {
+				continue
+			}
+
+			if resolved.DependencyManagement != nil {
+				imported = append(imported, resolved.DependencyManagement.Dependencies...)
+			}
+		} else {
+			remaining = append(remaining, dep)
+		}
+	}
+
+	// Build lookup of POM's own managed deps (non-import entries take precedence)
+	ownManaged := make(map[string]struct{})
+	for i := range remaining {
+		ownManaged[remaining[i].Key()] = struct{}{}
+	}
+
+	// Add imported deps that don't conflict with own
+	for i := range imported {
+		d := imported[i]
+		if _, exists := ownManaged[d.Key()]; !exists {
+			remaining = append(remaining, d)
+			ownManaged[d.Key()] = struct{}{}
+		}
+	}
+
+	pom.DependencyManagement.Dependencies = remaining
+	return nil
+}

--- a/source/maven/resolver_test.go
+++ b/source/maven/resolver_test.go
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAgentImpl implements khttp.AgentImplementation for testing.
+type fakeAgentImpl struct {
+	responses map[string]string // URL -> response body
+}
+
+func (f *fakeAgentImpl) SendGetRequest(_ *http.Client, url string) (*http.Response, error) {
+	body, ok := f.responses[url]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, fmt.Errorf("not found: %s", url)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func (f *fakeAgentImpl) SendPostRequest(_ *http.Client, _ string, _ []byte, _ string) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeAgentImpl) SendHeadRequest(_ *http.Client, _ string) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func newTestResolver(responses map[string]string) *Resolver {
+	r := NewResolver(&Options{
+		RepoURL:     "https://repo.test",
+		Concurrency: 1,
+	})
+	r.Agent = r.Agent.WithRetries(0)
+	r.Agent.SetImplementation(&fakeAgentImpl{responses: responses})
+	return r
+}
+
+func TestResolverPomURL(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(&Options{RepoURL: "https://repo.test"})
+	url := r.pomURL("org.apache.commons", "commons-lang3", "3.14.0")
+	require.Equal(t, "https://repo.test/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.pom", url)
+}
+
+func TestResolverMetadataURL(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(&Options{RepoURL: "https://repo.test"})
+	url := r.metadataURL("org.apache.commons", "commons-lang3")
+	require.Equal(t, "https://repo.test/org/apache/commons/commons-lang3/maven-metadata.xml", url)
+}
+
+func TestResolverFetchPOM(t *testing.T) {
+	t.Parallel()
+	pomXML := `<?xml version="1.0"?>
+<project>
+    <groupId>com.test</groupId>
+    <artifactId>test-lib</artifactId>
+    <version>1.0.0</version>
+</project>`
+
+	r := newTestResolver(map[string]string{
+		"https://repo.test/com/test/test-lib/1.0.0/test-lib-1.0.0.pom": pomXML,
+	})
+
+	pom, err := r.FetchPOM("com.test", "test-lib", "1.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "com.test", pom.GroupID)
+	require.Equal(t, "1.0.0", pom.Version)
+
+	// Second call should be cached
+	pom2, err := r.FetchPOM("com.test", "test-lib", "1.0.0")
+	require.NoError(t, err)
+	require.Equal(t, pom, pom2)
+}
+
+func TestResolverFetchPOMNotFound(t *testing.T) {
+	t.Parallel()
+	r := newTestResolver(map[string]string{})
+	_, err := r.FetchPOM("com.missing", "lib", "1.0")
+	require.Error(t, err)
+}
+
+func TestResolverFetchAvailableVersions(t *testing.T) {
+	t.Parallel()
+	metadataXML := `<?xml version="1.0"?>
+<metadata>
+    <groupId>com.test</groupId>
+    <artifactId>lib</artifactId>
+    <versioning>
+        <latest>2.0.0</latest>
+        <release>2.0.0</release>
+        <versions>
+            <version>1.0.0</version>
+            <version>1.1.0</version>
+            <version>2.0.0</version>
+        </versions>
+    </versioning>
+</metadata>`
+
+	r := newTestResolver(map[string]string{
+		"https://repo.test/com/test/lib/maven-metadata.xml": metadataXML,
+	})
+
+	versions, err := r.FetchAvailableVersions("com.test", "lib")
+	require.NoError(t, err)
+	require.Equal(t, []string{"1.0.0", "1.1.0", "2.0.0"}, versions)
+}
+
+func TestResolverResolveVersionRange(t *testing.T) {
+	t.Parallel()
+	metadataXML := `<?xml version="1.0"?>
+<metadata>
+    <versioning>
+        <versions>
+            <version>1.0</version>
+            <version>1.5</version>
+            <version>2.0</version>
+        </versions>
+    </versioning>
+</metadata>`
+
+	r := newTestResolver(map[string]string{
+		"https://repo.test/g/a/maven-metadata.xml": metadataXML,
+	})
+
+	v, err := r.ResolveVersionRange("g", "a", "[1.0,2.0)")
+	require.NoError(t, err)
+	require.Equal(t, "1.5", v)
+}
+
+func TestMergeParent(t *testing.T) {
+	t.Parallel()
+	parent := &POM{
+		GroupID:    "com.parent",
+		Version:    "1.0.0",
+		Properties: Properties{"parent.prop": "pval", "shared": "parent"},
+		DependencyManagement: &DependencyManagement{
+			Dependencies: []Dependency{
+				{GroupID: "g", ArtifactID: "managed", Version: "1.0"},
+				{GroupID: "g", ArtifactID: "only-parent", Version: "2.0"},
+			},
+		},
+		Licenses: []License{{Name: "Apache-2.0"}},
+	}
+
+	child := &POM{
+		ArtifactID: "child",
+		Properties: Properties{"child.prop": "cval", "shared": "child"},
+		DependencyManagement: &DependencyManagement{
+			Dependencies: []Dependency{
+				{GroupID: "g", ArtifactID: "managed", Version: "2.0"},
+			},
+		},
+	}
+
+	merged := MergeParent(child, parent)
+
+	// GroupID inherited from parent
+	require.Equal(t, "com.parent", merged.GroupID)
+
+	// Properties merged, child wins on conflicts
+	require.Equal(t, "pval", merged.Properties["parent.prop"])
+	require.Equal(t, "cval", merged.Properties["child.prop"])
+	require.Equal(t, "child", merged.Properties["shared"])
+
+	// DependencyManagement: child's "managed" wins, parent's "only-parent" inherited
+	require.Len(t, merged.DependencyManagement.Dependencies, 2)
+
+	// Licenses inherited
+	require.Len(t, merged.Licenses, 1)
+	require.Equal(t, "Apache-2.0", merged.Licenses[0].Name)
+}
+
+func TestResolveEffectivePOM(t *testing.T) {
+	t.Parallel()
+	parentPOM := `<?xml version="1.0"?>
+<project>
+    <groupId>com.parent</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <properties>
+        <lib.version>5.0.0</lib.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.managed</groupId>
+                <artifactId>lib</artifactId>
+                <version>${lib.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>`
+
+	r := newTestResolver(map[string]string{
+		"https://repo.test/com/parent/parent/1.0.0/parent-1.0.0.pom": parentPOM,
+	})
+
+	child := &POM{
+		ArtifactID: "child",
+		Version:    "2.0.0",
+		Parent: &Parent{
+			GroupID:    "com.parent",
+			ArtifactID: "parent",
+			Version:    "1.0.0",
+		},
+		Dependencies: []Dependency{
+			{GroupID: "com.managed", ArtifactID: "lib", Version: "${lib.version}"},
+		},
+	}
+
+	effective, err := r.ResolveEffectivePOM(child)
+	require.NoError(t, err)
+
+	// GroupID inherited from parent
+	require.Equal(t, "com.parent", effective.GroupID)
+
+	// Property inherited and interpolated
+	require.Equal(t, "5.0.0", effective.Dependencies[0].Version)
+
+	// DependencyManagement inherited
+	require.NotNil(t, effective.DependencyManagement)
+	require.Len(t, effective.DependencyManagement.Dependencies, 1)
+}
+
+func TestResolveBOMImports(t *testing.T) {
+	t.Parallel()
+	bomPOM := `<?xml version="1.0"?>
+<project>
+    <groupId>com.bom</groupId>
+    <artifactId>bom</artifactId>
+    <version>1.0.0</version>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.managed</groupId>
+                <artifactId>from-bom</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>`
+
+	r := newTestResolver(map[string]string{
+		"https://repo.test/com/bom/bom/1.0.0/bom-1.0.0.pom": bomPOM,
+	})
+
+	pom := &POM{
+		GroupID:    "com.test",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		DependencyManagement: &DependencyManagement{
+			Dependencies: []Dependency{
+				// BOM import
+				{GroupID: "com.bom", ArtifactID: "bom", Version: "1.0.0", Scope: "import", Type: "pom"},
+				// Own managed dep
+				{GroupID: "com.own", ArtifactID: "lib", Version: "2.0.0"},
+			},
+		},
+	}
+
+	err := r.resolveBOMImports(pom, 0)
+	require.NoError(t, err)
+
+	// BOM import entry should be removed, replaced by its contents
+	keys := make(map[string]string)
+	for _, d := range pom.DependencyManagement.Dependencies {
+		keys[d.Key()] = d.Version
+	}
+
+	require.Equal(t, "2.0.0", keys["com.own:lib"])
+	require.Equal(t, "3.0.0", keys["com.managed:from-bom"])
+	// BOM import itself should not remain
+	require.NotContains(t, keys, "com.bom:bom")
+}

--- a/source/maven/testdata/simple/pom.xml
+++ b/source/maven/testdata/simple/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>simple-app</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>Simple Test App</name>
+    <description>A simple Maven project for testing</description>
+    <url>https://example.com/simple-app</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <guava.version>33.0.0-jre</guava.version>
+        <commons.version>3.14.0</commons.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
 package maven

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -1,0 +1,418 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/protobom/protobom/pkg/sbom"
+
+	api "github.com/carabiner-dev/unpack/api/v1"
+)
+
+// ResolvedDependency represents a dependency after mediation.
+type ResolvedDependency struct {
+	Coordinate Coordinate
+	Scope      string
+	Optional   bool
+	Licenses   []License
+	Depth      int
+}
+
+// DependencyTree builds the resolved dependency graph from a Maven POM.
+type DependencyTree struct {
+	rootPOM  *POM
+	resolver *Resolver
+	opts     *Options
+
+	// Resolved dependencies keyed by "groupId:artifactId".
+	// Maven uses nearest-definition-wins: the first version
+	// encountered at the shallowest depth wins.
+	resolved map[string]*ResolvedDependency
+
+	// Adjacency list: parent coord string -> []child coord string
+	edges map[string][]string
+
+	// Managed dependencies from dependencyManagement, keyed by "groupId:artifactId"
+	managed map[string]*Dependency
+}
+
+// queueEntry is a BFS queue item for dependency resolution.
+type queueEntry struct {
+	dep         Dependency
+	parentCoord string
+	depth       int
+	parentScope string
+	exclusions  []Exclusion // accumulated from all ancestors
+}
+
+// NewDependencyTree creates a new dependency tree builder.
+func NewDependencyTree(rootPOM *POM, resolver *Resolver, opts *Options) *DependencyTree {
+	dt := &DependencyTree{
+		rootPOM:  rootPOM,
+		resolver: resolver,
+		opts:     opts,
+		resolved: make(map[string]*ResolvedDependency),
+		edges:    make(map[string][]string),
+		managed:  make(map[string]*Dependency),
+	}
+
+	// Index dependencyManagement
+	if rootPOM.DependencyManagement != nil {
+		for i := range rootPOM.DependencyManagement.Dependencies {
+			d := &rootPOM.DependencyManagement.Dependencies[i]
+			dt.managed[d.Key()] = d
+		}
+	}
+
+	return dt
+}
+
+// Build performs BFS dependency resolution and returns the resolved tree.
+func (dt *DependencyTree) Build() error {
+	rootCoord := Coordinate{
+		GroupID:    dt.rootPOM.EffectiveGroupID(),
+		ArtifactID: dt.rootPOM.ArtifactID,
+		Version:    dt.rootPOM.EffectiveVersion(),
+	}
+
+	// Add root to resolved set
+	dt.resolved[rootCoord.Key()] = &ResolvedDependency{
+		Coordinate: rootCoord,
+		Licenses:   dt.rootPOM.Licenses,
+		Depth:      0,
+	}
+
+	// Initialize BFS queue with direct dependencies
+	var queue []queueEntry
+	for i := range dt.rootPOM.Dependencies {
+		dep := dt.applyManagement(dt.rootPOM.Dependencies[i])
+		queue = append(queue, queueEntry{
+			dep:         dep,
+			parentCoord: rootCoord.String(),
+			depth:       1,
+			parentScope: ScopeCompile,
+		})
+	}
+
+	// BFS
+	for len(queue) > 0 {
+		entry := queue[0]
+		queue = queue[1:]
+
+		dep := entry.dep
+		key := dep.Key()
+
+		// Skip if already resolved (nearest definition wins)
+		if _, exists := dt.resolved[key]; exists {
+			continue
+		}
+
+		// Skip excluded dependencies
+		if dt.isExcluded(dep.GroupID, dep.ArtifactID, entry.exclusions) {
+			continue
+		}
+
+		// Determine effective scope
+		effectiveScope := dep.EffectiveScope()
+		if entry.depth > 1 {
+			effectiveScope = scopeTransitivity(entry.parentScope, effectiveScope)
+			if effectiveScope == "" {
+				continue // non-transitive scope combination
+			}
+		}
+
+		// Filter by scope options
+		if !dt.shouldIncludeScope(effectiveScope) {
+			continue
+		}
+
+		// Skip optional dependencies unless configured to include them
+		if dep.IsOptional() && !dt.opts.IncludeOptional {
+			continue
+		}
+
+		// Resolve version range if needed
+		version := dep.Version
+		if IsVersionRange(version) && dt.resolver != nil {
+			resolved, err := dt.resolver.ResolveVersionRange(dep.GroupID, dep.ArtifactID, version)
+			if err != nil {
+				continue // skip unresolvable ranges
+			}
+			version = resolved
+		}
+
+		coord := Coordinate{
+			GroupID:    dep.GroupID,
+			ArtifactID: dep.ArtifactID,
+			Version:    version,
+		}
+
+		// Fetch the dependency's POM for license info and transitive deps
+		var licenses []License
+		var transitiveDeps []Dependency
+		if dt.resolver != nil && version != "" {
+			depPOM, err := dt.resolver.FetchPOM(dep.GroupID, dep.ArtifactID, version)
+			if err == nil {
+				// Try to resolve effective POM for accurate data
+				effective, err := dt.resolver.ResolveEffectivePOM(depPOM)
+				if err == nil {
+					depPOM = effective
+				}
+				licenses = depPOM.Licenses
+				transitiveDeps = depPOM.Dependencies
+			}
+		}
+
+		// Add to resolved set
+		dt.resolved[key] = &ResolvedDependency{
+			Coordinate: coord,
+			Scope:      effectiveScope,
+			Optional:   dep.IsOptional(),
+			Licenses:   licenses,
+			Depth:      entry.depth,
+		}
+
+		// Record edge
+		dt.edges[entry.parentCoord] = append(dt.edges[entry.parentCoord], coord.String())
+
+		// Enqueue transitive dependencies
+		// Accumulate exclusions from this dependency
+		allExclusions := append(entry.exclusions, dep.Exclusions...) //nolint:gocritic
+
+		for i := range transitiveDeps {
+			tdep := dt.applyManagement(transitiveDeps[i])
+			tScope := tdep.EffectiveScope()
+
+			// Only compile and runtime deps are transitive
+			if tScope != ScopeCompile && tScope != ScopeRuntime {
+				continue
+			}
+
+			queue = append(queue, queueEntry{
+				dep:         tdep,
+				parentCoord: coord.String(),
+				depth:       entry.depth + 1,
+				parentScope: effectiveScope,
+				exclusions:  allExclusions,
+			})
+		}
+	}
+
+	return nil
+}
+
+// applyManagement applies dependencyManagement overrides to a dependency.
+func (dt *DependencyTree) applyManagement(dep Dependency) Dependency { //nolint:gocritic // returns modified copy
+	managed, ok := dt.managed[dep.Key()]
+	if !ok {
+		return dep
+	}
+
+	if dep.Version == "" && managed.Version != "" {
+		dep.Version = managed.Version
+	}
+	if dep.Scope == "" && managed.Scope != "" {
+		dep.Scope = managed.Scope
+	}
+	if len(dep.Exclusions) == 0 && len(managed.Exclusions) > 0 {
+		dep.Exclusions = managed.Exclusions
+	}
+
+	return dep
+}
+
+// isExcluded checks if a dependency is excluded by any accumulated exclusion.
+func (dt *DependencyTree) isExcluded(groupID, artifactID string, exclusions []Exclusion) bool {
+	for _, excl := range exclusions {
+		if excl.Matches(groupID, artifactID) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldIncludeScope returns true if a dependency with the given scope should be included.
+func (dt *DependencyTree) shouldIncludeScope(scope string) bool {
+	switch scope {
+	case ScopeCompile, ScopeRuntime:
+		return true
+	case ScopeTest:
+		return dt.opts.IncludeTest
+	case ScopeProvided:
+		return dt.opts.IncludeProvided
+	case ScopeSystem:
+		return false
+	default:
+		return true
+	}
+}
+
+// scopeTransitivity implements Maven's scope transitivity rules.
+// Returns "" if the combination is non-transitive.
+func scopeTransitivity(parentScope, depScope string) string {
+	if depScope == ScopeProvided || depScope == ScopeTest {
+		return "" // provided and test are never transitive
+	}
+
+	switch parentScope {
+	case ScopeCompile:
+		if depScope == ScopeCompile {
+			return ScopeCompile
+		}
+		return ScopeRuntime
+	case ScopeProvided:
+		return ScopeProvided
+	case ScopeRuntime:
+		return ScopeRuntime
+	case ScopeTest:
+		return ScopeTest
+	default:
+		return depScope
+	}
+}
+
+// ToNodeList converts the resolved dependency tree to a protobom NodeList.
+func (dt *DependencyTree) ToNodeList(opts *api.DecomposerOptions) (*sbom.NodeList, error) {
+	nl := sbom.NewNodeList()
+
+	rootCoord := Coordinate{
+		GroupID:    dt.rootPOM.EffectiveGroupID(),
+		ArtifactID: dt.rootPOM.ArtifactID,
+		Version:    dt.rootPOM.EffectiveVersion(),
+	}
+
+	// Use version from options if provided
+	version := rootCoord.Version
+	if opts != nil && opts.Version != "" {
+		version = opts.Version
+	}
+	rootCoord.Version = version
+
+	// Create root node
+	rootNode := &sbom.Node{
+		Id:      uuid.NewString(),
+		Type:    sbom.Node_PACKAGE,
+		Name:    rootCoord.ArtifactID,
+		Version: version,
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): rootCoord.PURL(),
+		},
+		PrimaryPurpose: []sbom.Purpose{sbom.Purpose_APPLICATION},
+	}
+
+	// Add licenses from root POM
+	for _, lic := range dt.rootPOM.Licenses {
+		rootNode.Licenses = append(rootNode.Licenses, lic.Name)
+	}
+
+	if opts != nil && opts.CommitHash != "" {
+		rootNode.ExternalReferences = append(rootNode.ExternalReferences, &sbom.ExternalReference{
+			Hashes: map[int32]string{
+				int32(sbom.HashAlgorithm_SHA1): opts.CommitHash,
+			},
+			Type: sbom.ExternalReference_VCS,
+		})
+	}
+
+	nl.AddRootNode(rootNode)
+
+	// Create a map of coord string -> node for linking
+	nodeMap := map[string]*sbom.Node{
+		rootCoord.String(): rootNode,
+	}
+
+	// Create nodes for all resolved dependencies
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(dt.resolved))
+	for k := range dt.resolved {
+		if k == rootCoord.Key() {
+			continue // skip root
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		rd := dt.resolved[key]
+		node := dt.createDependencyNode(rd)
+		nodeMap[rd.Coordinate.String()] = node
+	}
+
+	// Create edges
+	for parentCoord, children := range dt.edges {
+		parentNode, ok := nodeMap[parentCoord]
+		if !ok {
+			continue
+		}
+
+		for _, childCoord := range children {
+			childNode, ok := nodeMap[childCoord]
+			if !ok {
+				continue
+			}
+
+			// Determine edge type based on the child's scope
+			edgeType := dt.edgeTypeForCoord(childCoord)
+			if err := nl.RelateNodeAtID(childNode, parentNode.GetId(), edgeType); err != nil {
+				return nil, fmt.Errorf("relating %s to %s: %w", childCoord, parentCoord, err)
+			}
+		}
+	}
+
+	return nl, nil
+}
+
+// createDependencyNode creates a protobom Node for a resolved dependency.
+func (dt *DependencyTree) createDependencyNode(rd *ResolvedDependency) *sbom.Node {
+	groupPath := strings.ReplaceAll(rd.Coordinate.GroupID, ".", "/")
+	downloadURL := fmt.Sprintf("%s/%s/%s/%s/%s-%s.jar",
+		defaultRepoURL, groupPath,
+		rd.Coordinate.ArtifactID, rd.Coordinate.Version,
+		rd.Coordinate.ArtifactID, rd.Coordinate.Version,
+	)
+
+	node := &sbom.Node{
+		Id:          uuid.NewString(),
+		Type:        sbom.Node_PACKAGE,
+		Name:        rd.Coordinate.ArtifactID,
+		Version:     rd.Coordinate.Version,
+		UrlDownload: downloadURL,
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): rd.Coordinate.PURL(),
+		},
+		Hashes: map[int32]string{},
+		PrimaryPurpose: []sbom.Purpose{
+			sbom.Purpose_LIBRARY,
+		},
+	}
+
+	for _, lic := range rd.Licenses {
+		node.Licenses = append(node.Licenses, lic.Name)
+	}
+
+	return node
+}
+
+// edgeTypeForCoord returns the appropriate edge type for a dependency.
+func (dt *DependencyTree) edgeTypeForCoord(coordStr string) sbom.Edge_Type {
+	// Find the resolved dependency by matching coord string
+	for _, rd := range dt.resolved {
+		if rd.Coordinate.String() == coordStr {
+			if rd.Optional {
+				return sbom.Edge_optionalDependency
+			}
+			switch rd.Scope {
+			case ScopeTest:
+				return sbom.Edge_devDependency
+			default:
+				return sbom.Edge_dependsOn
+			}
+		}
+	}
+	return sbom.Edge_dependsOn
+}

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -164,7 +164,31 @@ func (dt *DependencyTree) Build() error {
 					depPOM = effective
 				}
 				licenses = depPOM.Licenses
-				transitiveDeps = depPOM.Dependencies
+
+				// Apply the dep's own dependencyManagement to its dependencies
+				// so that version-less deps get their versions filled in.
+				depManaged := make(map[string]*Dependency)
+				if depPOM.DependencyManagement != nil {
+					for i := range depPOM.DependencyManagement.Dependencies {
+						d := &depPOM.DependencyManagement.Dependencies[i]
+						depManaged[d.Key()] = d
+					}
+				}
+				for i := range depPOM.Dependencies {
+					d := depPOM.Dependencies[i]
+					if m, ok := depManaged[d.Key()]; ok {
+						if d.Version == "" && m.Version != "" {
+							d.Version = m.Version
+						}
+						if d.Scope == "" && m.Scope != "" {
+							d.Scope = m.Scope
+						}
+						if len(d.Exclusions) == 0 && len(m.Exclusions) > 0 {
+							d.Exclusions = m.Exclusions
+						}
+					}
+					transitiveDeps = append(transitiveDeps, d)
+				}
 			}
 		}
 

--- a/source/maven/tree_test.go
+++ b/source/maven/tree_test.go
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeTransitivity(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		parentScope string
+		depScope    string
+		want        string
+	}{
+		// compile parent
+		{"compile+compile", ScopeCompile, ScopeCompile, ScopeCompile},
+		{"compile+runtime", ScopeCompile, ScopeRuntime, ScopeRuntime},
+		{"compile+provided", ScopeCompile, ScopeProvided, ""},
+		{"compile+test", ScopeCompile, ScopeTest, ""},
+
+		// provided parent
+		{"provided+compile", ScopeProvided, ScopeCompile, ScopeProvided},
+		{"provided+runtime", ScopeProvided, ScopeRuntime, ScopeProvided},
+		{"provided+provided", ScopeProvided, ScopeProvided, ""},
+
+		// runtime parent
+		{"runtime+compile", ScopeRuntime, ScopeCompile, ScopeRuntime},
+		{"runtime+runtime", ScopeRuntime, ScopeRuntime, ScopeRuntime},
+		{"runtime+provided", ScopeRuntime, ScopeProvided, ""},
+
+		// test parent
+		{"test+compile", ScopeTest, ScopeCompile, ScopeTest},
+		{"test+runtime", ScopeTest, ScopeRuntime, ScopeTest},
+		{"test+provided", ScopeTest, ScopeProvided, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := scopeTransitivity(tc.parentScope, tc.depScope)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBuildSimpleTree(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{GroupID: "com.dep", ArtifactID: "lib-a", Version: "1.0"},
+			{GroupID: "com.dep", ArtifactID: "lib-b", Version: "2.0"},
+		},
+	}
+
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	// Root + 2 dependencies
+	require.Len(t, dt.resolved, 3)
+	require.Contains(t, dt.resolved, "com.example:app")
+	require.Contains(t, dt.resolved, "com.dep:lib-a")
+	require.Contains(t, dt.resolved, "com.dep:lib-b")
+
+	require.Equal(t, "1.0", dt.resolved["com.dep:lib-a"].Coordinate.Version)
+	require.Equal(t, ScopeCompile, dt.resolved["com.dep:lib-a"].Scope)
+}
+
+func TestBuildTreeScopeFiltering(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{GroupID: "com.dep", ArtifactID: "compile-dep", Version: "1.0"},
+			{GroupID: "com.dep", ArtifactID: "test-dep", Version: "1.0", Scope: ScopeTest},
+			{GroupID: "com.dep", ArtifactID: "provided-dep", Version: "1.0", Scope: ScopeProvided},
+		},
+	}
+
+	// Default options: no test, no provided
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	require.Contains(t, dt.resolved, "com.dep:compile-dep")
+	require.NotContains(t, dt.resolved, "com.dep:test-dep")
+	require.NotContains(t, dt.resolved, "com.dep:provided-dep")
+
+	// With test scope included
+	opts := Options{IncludeTest: true}
+	dt = NewDependencyTree(pom, nil, &opts)
+	err = dt.Build()
+	require.NoError(t, err)
+	require.Contains(t, dt.resolved, "com.dep:test-dep")
+}
+
+func TestBuildTreeOptionalFiltering(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{GroupID: "com.dep", ArtifactID: "normal", Version: "1.0"},
+			{GroupID: "com.dep", ArtifactID: "optional", Version: "1.0", Optional: "true"},
+		},
+	}
+
+	// Default: no optional
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+	require.NotContains(t, dt.resolved, "com.dep:optional")
+
+	// With optional included
+	opts := Options{IncludeOptional: true}
+	dt = NewDependencyTree(pom, nil, &opts)
+	err = dt.Build()
+	require.NoError(t, err)
+	require.Contains(t, dt.resolved, "com.dep:optional")
+}
+
+func TestBuildTreeNearestWins(t *testing.T) {
+	t.Parallel()
+	// Simulate: app -> lib-a -> shared:1.0, app -> lib-b -> shared:2.0
+	// Both at depth 2, so first encountered (lib-a's shared:1.0) wins
+	// But since we can't set up transitive deps without a resolver,
+	// test with two direct deps of the same groupId:artifactId
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{GroupID: "com.dep", ArtifactID: "lib", Version: "1.0"},
+			{GroupID: "com.dep", ArtifactID: "lib", Version: "2.0"},
+		},
+	}
+
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	// First version wins
+	require.Equal(t, "1.0", dt.resolved["com.dep:lib"].Coordinate.Version)
+}
+
+func TestBuildTreeExclusions(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		DependencyManagement: &DependencyManagement{
+			Dependencies: []Dependency{
+				{
+					GroupID:    "com.dep",
+					ArtifactID: "parent-lib",
+					Version:    "1.0",
+					Exclusions: []Exclusion{
+						{GroupID: "com.excluded", ArtifactID: "lib"},
+					},
+				},
+			},
+		},
+		Dependencies: []Dependency{
+			{GroupID: "com.dep", ArtifactID: "parent-lib"},
+			{GroupID: "com.excluded", ArtifactID: "lib", Version: "1.0"},
+		},
+	}
+
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	// parent-lib is resolved
+	require.Contains(t, dt.resolved, "com.dep:parent-lib")
+	// excluded lib should still be resolved since exclusions only apply to transitive deps
+	// (direct dependencies are not affected by exclusions from other dependencies)
+	require.Contains(t, dt.resolved, "com.excluded:lib")
+}
+
+func TestBuildTreeDependencyManagement(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		DependencyManagement: &DependencyManagement{
+			Dependencies: []Dependency{
+				{GroupID: "com.dep", ArtifactID: "managed", Version: "5.0.0"},
+			},
+		},
+		Dependencies: []Dependency{
+			// No version specified, should come from management
+			{GroupID: "com.dep", ArtifactID: "managed"},
+		},
+	}
+
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	require.Equal(t, "5.0.0", dt.resolved["com.dep:managed"].Coordinate.Version)
+}
+
+func TestToNodeList(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Licenses:   []License{{Name: "Apache-2.0"}},
+		Dependencies: []Dependency{
+			{GroupID: "com.dep", ArtifactID: "lib", Version: "2.0"},
+		},
+	}
+
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	nl, err := dt.ToNodeList(nil)
+	require.NoError(t, err)
+
+	// Root node + 1 dependency
+	require.Len(t, nl.GetRootElements(), 1)
+
+	nodes := nl.GetNodes()
+	require.Len(t, nodes, 2)
+
+	// Check root node
+	root := nl.GetRootElements()[0]
+	rootNode := nl.GetNodeByID(root)
+	require.Equal(t, "app", rootNode.GetName())
+	require.Equal(t, "1.0.0", rootNode.GetVersion())
+	require.Contains(t, rootNode.GetIdentifiers(), int32(1)) // PURL
+	require.Equal(t, "pkg:maven/com.example/app@1.0.0", rootNode.GetIdentifiers()[int32(1)])
+}
+
+func TestToNodeListEdgeTypes(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Dependencies: []Dependency{
+			{GroupID: "com.dep", ArtifactID: "compile-dep", Version: "1.0"},
+			{GroupID: "com.dep", ArtifactID: "test-dep", Version: "1.0", Scope: ScopeTest},
+		},
+	}
+
+	opts := Options{IncludeTest: true}
+	dt := NewDependencyTree(pom, nil, &opts)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	nl, err := dt.ToNodeList(nil)
+	require.NoError(t, err)
+
+	// Should have 3 nodes: root + 2 deps
+	require.Len(t, nl.GetNodes(), 3)
+}

--- a/source/maven/version.go
+++ b/source/maven/version.go
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// Coordinate uniquely identifies a Maven artifact.
+type Coordinate struct {
+	GroupID    string
+	ArtifactID string
+	Version    string
+	Classifier string
+	Type       string
+}
+
+// String returns "groupId:artifactId:version".
+func (c Coordinate) String() string {
+	return fmt.Sprintf("%s:%s:%s", c.GroupID, c.ArtifactID, c.Version)
+}
+
+// PURL returns the Package URL for this coordinate.
+func (c *Coordinate) PURL() string {
+	purl := fmt.Sprintf("pkg:maven/%s/%s", c.GroupID, c.ArtifactID)
+	if c.Version != "" {
+		purl += "@" + c.Version
+	}
+	return purl
+}
+
+// Key returns "groupId:artifactId" for mediation lookups.
+func (c *Coordinate) Key() string {
+	return c.GroupID + ":" + c.ArtifactID
+}
+
+// qualifierRank returns the ordering rank for known Maven qualifiers.
+// Lower values sort earlier. Unknown qualifiers get a high rank.
+func qualifierRank(q string) int {
+	switch strings.ToLower(q) {
+	case "alpha", "a":
+		return 1
+	case "beta", "b":
+		return 2
+	case "milestone", "m":
+		return 3
+	case "rc", "cr":
+		return 4
+	case "snapshot":
+		return 5
+	case "", "final", "ga", "release":
+		return 6
+	case "sp":
+		return 7
+	default:
+		return 8
+	}
+}
+
+// versionItem represents one segment of a parsed Maven version.
+// It can be either numeric or string-typed.
+type versionItem struct {
+	numeric   int
+	qualifier string
+	isNumeric bool
+}
+
+// parseVersionItems splits a Maven version string into comparable items.
+// Maven version strings are split on '.', '-', and digit/letter transitions.
+func parseVersionItems(s string) []versionItem {
+	if s == "" {
+		return nil
+	}
+
+	var items []versionItem
+	var current strings.Builder
+	prevIsDigit := false
+
+	flush := func() {
+		tok := current.String()
+		current.Reset()
+		if tok == "" {
+			return
+		}
+		if n, err := strconv.Atoi(tok); err == nil {
+			items = append(items, versionItem{numeric: n, isNumeric: true})
+		} else {
+			items = append(items, versionItem{qualifier: tok})
+		}
+	}
+
+	for i, ch := range s {
+		isDigit := unicode.IsDigit(ch)
+		if ch == '.' || ch == '-' {
+			flush()
+			prevIsDigit = false
+			continue
+		}
+		// Split on digit<->letter transitions
+		if i > 0 && current.Len() > 0 && isDigit != prevIsDigit {
+			flush()
+		}
+		current.WriteRune(ch)
+		prevIsDigit = isDigit
+	}
+	flush()
+	return items
+}
+
+// CompareVersions compares two Maven version strings.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+func CompareVersions(a, b string) int {
+	itemsA := parseVersionItems(a)
+	itemsB := parseVersionItems(b)
+
+	maxLen := len(itemsA)
+	if len(itemsB) > maxLen {
+		maxLen = len(itemsB)
+	}
+
+	for i := range maxLen {
+		var ia, ib versionItem
+		if i < len(itemsA) {
+			ia = itemsA[i]
+		}
+		if i < len(itemsB) {
+			ib = itemsB[i]
+		}
+
+		cmp := compareItems(ia, ib)
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	return 0
+}
+
+// compareItems compares two version items.
+func compareItems(a, b versionItem) int {
+	// Both numeric: compare as integers
+	if a.isNumeric && b.isNumeric {
+		return intCmp(a.numeric, b.numeric)
+	}
+
+	// Both qualifiers: compare by rank then lexically
+	if !a.isNumeric && !b.isNumeric {
+		rankA := qualifierRank(a.qualifier)
+		rankB := qualifierRank(b.qualifier)
+		if rankA != rankB {
+			return intCmp(rankA, rankB)
+		}
+		// Same rank bucket (both unknown): compare lexically
+		if rankA == 8 {
+			return strings.Compare(strings.ToLower(a.qualifier), strings.ToLower(b.qualifier))
+		}
+		return 0
+	}
+
+	// One is numeric, one is qualifier (or missing)
+	// A missing item is equivalent to 0 (numeric) or "" (release qualifier)
+	if a.isNumeric && !b.isNumeric {
+		// numeric vs qualifier: if qualifier is release-equivalent, numeric wins on value
+		if b.qualifier == "" {
+			// missing item = 0, compare a.numeric to 0
+			return intCmp(a.numeric, 0)
+		}
+		// A number is always "newer" than a qualifier
+		return 1
+	}
+
+	// qualifier vs numeric
+	if a.qualifier == "" {
+		return intCmp(0, b.numeric)
+	}
+	return -1
+}
+
+func intCmp(a, b int) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+// VersionRange represents a Maven version range constraint.
+type VersionRange struct {
+	LowerBound     string
+	UpperBound     string
+	LowerInclusive bool
+	UpperInclusive bool
+}
+
+// IsVersionRange returns true if the string looks like a Maven version range.
+func IsVersionRange(s string) bool {
+	return strings.HasPrefix(s, "[") || strings.HasPrefix(s, "(")
+}
+
+// ParseVersionRange parses a Maven version range string.
+// Supported formats: [1.0,2.0), [1.0], (,1.0], [1.0,), etc.
+func ParseVersionRange(s string) (*VersionRange, error) {
+	if len(s) < 2 {
+		return nil, fmt.Errorf("invalid version range: %q", s)
+	}
+
+	first := s[0]
+	last := s[len(s)-1]
+
+	var lowerInclusive, upperInclusive bool
+	switch first {
+	case '[':
+		lowerInclusive = true
+	case '(':
+		lowerInclusive = false
+	default:
+		return nil, fmt.Errorf("invalid version range start: %q", s)
+	}
+	switch last {
+	case ']':
+		upperInclusive = true
+	case ')':
+		upperInclusive = false
+	default:
+		return nil, fmt.Errorf("invalid version range end: %q", s)
+	}
+
+	inner := s[1 : len(s)-1]
+	parts := strings.SplitN(inner, ",", 2)
+
+	vr := &VersionRange{
+		LowerInclusive: lowerInclusive,
+		UpperInclusive: upperInclusive,
+	}
+
+	if len(parts) == 1 {
+		// Exact version: [1.0]
+		vr.LowerBound = strings.TrimSpace(parts[0])
+		vr.UpperBound = vr.LowerBound
+		vr.LowerInclusive = true
+		vr.UpperInclusive = true
+	} else {
+		vr.LowerBound = strings.TrimSpace(parts[0])
+		vr.UpperBound = strings.TrimSpace(parts[1])
+	}
+
+	return vr, nil
+}
+
+// Contains returns true if the given version satisfies this range.
+func (vr *VersionRange) Contains(version string) bool {
+	if vr.LowerBound != "" {
+		cmp := CompareVersions(version, vr.LowerBound)
+		if vr.LowerInclusive && cmp < 0 {
+			return false
+		}
+		if !vr.LowerInclusive && cmp <= 0 {
+			return false
+		}
+	}
+
+	if vr.UpperBound != "" {
+		cmp := CompareVersions(version, vr.UpperBound)
+		if vr.UpperInclusive && cmp > 0 {
+			return false
+		}
+		if !vr.UpperInclusive && cmp >= 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// SelectVersion picks the highest version from candidates that satisfies the range.
+func (vr *VersionRange) SelectVersion(candidates []string) string {
+	var best string
+	for _, v := range candidates {
+		if !vr.Contains(v) {
+			continue
+		}
+		if best == "" || CompareVersions(v, best) > 0 {
+			best = v
+		}
+	}
+	return best
+}

--- a/source/maven/version_test.go
+++ b/source/maven/version_test.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoordinatePURL(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		coord Coordinate
+		purl  string
+	}{
+		{"basic", Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.0.0-jre"}, "pkg:maven/com.google.guava/guava@33.0.0-jre"},
+		{"no version", Coordinate{GroupID: "g", ArtifactID: "a"}, "pkg:maven/g/a"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.purl, tc.coord.PURL())
+		})
+	}
+}
+
+func TestCoordinateString(t *testing.T) {
+	t.Parallel()
+	c := Coordinate{GroupID: "g", ArtifactID: "a", Version: "1.0"}
+	require.Equal(t, "g:a:1.0", c.String())
+}
+
+func TestCoordinateKey(t *testing.T) {
+	t.Parallel()
+	c := Coordinate{GroupID: "g", ArtifactID: "a", Version: "1.0"}
+	require.Equal(t, "g:a", c.Key())
+}
+
+func TestCompareVersions(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		a, b string
+		want int
+	}{
+		// Basic numeric
+		{"equal", "1.0.0", "1.0.0", 0},
+		{"major", "2.0.0", "1.0.0", 1},
+		{"minor", "1.1.0", "1.0.0", 1},
+		{"patch", "1.0.1", "1.0.0", 1},
+		{"reverse", "1.0.0", "2.0.0", -1},
+
+		// Different segment counts
+		{"short vs long equal", "1.0", "1.0.0", 0},
+		{"short vs long less", "1.0", "1.0.1", -1},
+
+		// Qualifiers
+		{"alpha < beta", "1.0-alpha", "1.0-beta", -1},
+		{"beta < rc", "1.0-beta", "1.0-rc", -1},
+		{"rc < release", "1.0-rc1", "1.0", -1},
+		{"snapshot < release", "1.0-SNAPSHOT", "1.0", -1},
+		{"release < sp", "1.0", "1.0-sp1", -1},
+		{"alpha aliases", "1.0-a1", "1.0-alpha1", 0},
+		{"beta aliases", "1.0-b1", "1.0-beta1", 0},
+		{"final = release", "1.0-final", "1.0", 0},
+		{"ga = release", "1.0-ga", "1.0", 0},
+
+		// JRE qualifier (unknown, sorts after sp)
+		{"jre qualifier", "33.0.0-android", "33.0.0-jre", -1}, // both unknown, lexical
+
+		// Mixed
+		{"1.0-alpha vs 1.0.0", "1.0-alpha", "1.0.0", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := CompareVersions(tc.a, tc.b)
+			require.Equal(t, tc.want, got, "CompareVersions(%q, %q)", tc.a, tc.b)
+		})
+	}
+}
+
+func TestIsVersionRange(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsVersionRange("[1.0,2.0)"))
+	require.True(t, IsVersionRange("(,1.0]"))
+	require.True(t, IsVersionRange("[1.0]"))
+	require.False(t, IsVersionRange("1.0.0"))
+	require.False(t, IsVersionRange(""))
+}
+
+func TestParseVersionRange(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		input   string
+		lower   string
+		upper   string
+		lowerIn bool
+		upperIn bool
+		mustErr bool
+	}{
+		{"inclusive range", "[1.0,2.0]", "1.0", "2.0", true, true, false},
+		{"half open", "[1.0,2.0)", "1.0", "2.0", true, false, false},
+		{"open lower", "(1.0,2.0]", "1.0", "2.0", false, true, false},
+		{"exact", "[1.0]", "1.0", "1.0", true, true, false},
+		{"unbounded upper", "[1.0,)", "1.0", "", true, false, false},
+		{"unbounded lower", "(,2.0)", "", "2.0", false, false, false},
+		{"invalid", "x", "", "", false, false, true},
+		{"too short", "[", "", "", false, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vr, err := ParseVersionRange(tc.input)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.lower, vr.LowerBound)
+			require.Equal(t, tc.upper, vr.UpperBound)
+			require.Equal(t, tc.lowerIn, vr.LowerInclusive)
+			require.Equal(t, tc.upperIn, vr.UpperInclusive)
+		})
+	}
+}
+
+func TestVersionRangeContains(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		rangeS  string
+		version string
+		want    bool
+	}{
+		{"in range", "[1.0,2.0)", "1.5", true},
+		{"at lower inclusive", "[1.0,2.0)", "1.0", true},
+		{"at upper exclusive", "[1.0,2.0)", "2.0", false},
+		{"at upper inclusive", "[1.0,2.0]", "2.0", true},
+		{"below range", "[1.0,2.0)", "0.9", false},
+		{"above range", "[1.0,2.0)", "2.1", false},
+		{"exact match", "[1.5]", "1.5", true},
+		{"exact no match", "[1.5]", "1.6", false},
+		{"unbounded upper", "[1.0,)", "99.0", true},
+		{"unbounded lower", "(,2.0)", "1.0", true},
+		{"unbounded lower at bound", "(,2.0)", "2.0", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vr, err := ParseVersionRange(tc.rangeS)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, vr.Contains(tc.version))
+		})
+	}
+}
+
+func TestVersionRangeSelectVersion(t *testing.T) {
+	t.Parallel()
+	vr, err := ParseVersionRange("[1.0,2.0)")
+	require.NoError(t, err)
+
+	candidates := []string{"0.9", "1.0", "1.5", "1.9", "2.0", "2.1"}
+	require.Equal(t, "1.9", vr.SelectVersion(candidates))
+
+	// No candidates match
+	require.Empty(t, vr.SelectVersion([]string{"0.5", "2.0", "3.0"}))
+}


### PR DESCRIPTION
This pull request adds support for Maven project decomposition to the codebase. It introduces a new Maven decomposer implementation, including the ability to parse `pom.xml` files, resolve Maven dependencies, and handle property interpolation. The changes are well-tested with new unit tests covering the Maven decomposer and POM parsing logic. Additionally, the pull request updates dependencies in `go.mod` to support the new functionality.

**Maven support implementation:**

* Added a new Maven decomposer in `source/maven/decomposer.go` that can extract dependency data from Maven projects by parsing `pom.xml`, resolving dependencies, and building a dependency graph.
* Implemented robust POM file parsing and model representation in `source/maven/pom.go`, including support for dependencies, dependency management, properties, exclusions, and licenses.
* Added property interpolation logic in `source/maven/properties.go` to resolve `${...}` placeholders in POM fields and dependencies, including recursive references and implicit project properties.

**Testing:**

* Added comprehensive unit tests for Maven POM parsing and property interpolation in `source/maven/pom_test.go`, and for the Maven decomposer in `source/maven/decomposer_test.go`. [[1]](diffhunk://#diff-efc9bb161a24d6ec72886fb46fa4c9fb0f9ca4af3d4c3ef7e89839917da4125aR1-R166) [[2]](diffhunk://#diff-0813f12d0a386dce397590f2ede3fff1a4459e6e83b03f0a2d1cc5212abd5781R1-R96)

**Integration and dependency updates:**

* Registered the Maven decomposer in the main unpacker (`dependencies/unpacker.go`) so Maven projects are now supported. [[1]](diffhunk://#diff-2644a7b5d25dac758266bc466de16c3594c2355f4a7fd64f8ffece271c533619R18) [[2]](diffhunk://#diff-2644a7b5d25dac758266bc466de16c3594c2355f4a7fd64f8ffece271c533619R33)
* Updated `go.mod` dependencies to include required libraries for Maven support and testing. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R12) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R33) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L52)