### PR TITLE
Bug fixes galore

### DIFF
--- a/source/golang/decomposer.go
+++ b/source/golang/decomposer.go
@@ -6,6 +6,8 @@ package golang
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -76,7 +78,7 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 	}
 
 	// 2. Build dependency tree by fetching go.mod files from the proxy
-	trees, err := d.buildDependencyTree(modFile, goModPath, dOpts)
+	trees, sumHashes, err := d.buildDependencyTree(modFile, goModPath, dOpts)
 	if err != nil {
 		return nil, fmt.Errorf("building dependency tree: %w", err)
 	}
@@ -87,7 +89,7 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 	if modFile.Go != nil {
 		goVersion = modFile.Go.Version
 	}
-	nl, err := d.convertTrees(opts, root, trees, goVersion)
+	nl, err := d.convertTrees(opts, root, trees, goVersion, sumHashes)
 	if err != nil {
 		return nil, fmt.Errorf("converting graph trees: %w", err)
 	}
@@ -146,8 +148,17 @@ func (d *Decomposer) parseGoSum(path string) (map[string][]string, error) {
 		version := parts[1]
 		hash := parts[2]
 
-		// Strip /go.mod suffix from version if present
-		version = strings.TrimSuffix(version, "/go.mod")
+		// Skip /go.mod entries — those are hashes of just the go.mod file,
+		// not the module zip archive. We still need them for dependency
+		// discovery (the key exists), but we don't mix them with zip hashes.
+		if strings.HasSuffix(version, "/go.mod") {
+			version = strings.TrimSuffix(version, "/go.mod")
+			key := fmt.Sprintf("%s@%s", modPath, version)
+			if _, exists := hashes[key]; !exists {
+				hashes[key] = nil // ensure the key exists for dependency discovery
+			}
+			continue
+		}
 
 		key := fmt.Sprintf("%s@%s", modPath, version)
 		hashes[key] = append(hashes[key], hash)
@@ -168,7 +179,7 @@ type replaceTarget struct {
 // 3. Building edges only between modules in the resolved set\
 //
 //nolint:gocritic,unparam
-func (d *Decomposer) buildDependencyTree(root *modfile.File, goModPath string, opts *Options) (*map[string][]string, error) {
+func (d *Decomposer) buildDependencyTree(root *modfile.File, goModPath string, opts *Options) (*map[string][]string, map[string][]string, error) {
 	trees := make(map[string][]string)
 
 	// Build replace directive map
@@ -209,7 +220,9 @@ func (d *Decomposer) buildDependencyTree(root *modfile.File, goModPath string, o
 	// Also parse go.sum to get all transitive dependencies
 	// These are needed to build the complete dependency graph
 	goSumPath := strings.TrimSuffix(goModPath, ".mod") + ".sum"
+	var allSumHashes map[string][]string
 	if sumHashes, err := d.parseGoSum(goSumPath); err == nil {
+		allSumHashes = sumHashes
 		for modKey := range sumHashes {
 			// Don't overwrite direct dependencies already in the set
 			if _, exists := resolvedSet[modKey]; !exists {
@@ -224,7 +237,7 @@ func (d *Decomposer) buildDependencyTree(root *modfile.File, goModPath string, o
 	// Fetch go.mod files for all modules in the resolved set to get their dependencies
 	d.fetchDependencyGraph(trees, resolvedSet, replaces, opts)
 
-	return &trees, nil
+	return &trees, allSumHashes, nil
 }
 
 // fetchDependencyGraph fetches go.mod files for all modules in the resolved set
@@ -395,7 +408,7 @@ func isLocalReplace(path string) bool {
 // convertTrees reads the tree map parsed from the go graph output and
 // converts it to a protobom NodeList, capturing the graph structure.
 func (d *Decomposer) convertTrees(
-	opts *api.DecomposerOptions, root string, trees *map[string][]string, goVersion string, //nolint:gocritic
+	opts *api.DecomposerOptions, root string, trees *map[string][]string, goVersion string, sumHashes map[string][]string, //nolint:gocritic
 ) (nl *sbom.NodeList, err error) {
 	// Create the new NodeList
 	nl = sbom.NewNodeList()
@@ -414,7 +427,7 @@ func (d *Decomposer) convertTrees(
 	nl.AddRootNode(rootNode)
 
 	// Run the recursive tree converter
-	if err = d.convertTree(nl, []string{root}, trees, &map[string]struct{}{}); err != nil {
+	if err = d.convertTree(nl, []string{root}, trees, sumHashes, &map[string]struct{}{}); err != nil {
 		return nil, fmt.Errorf("error running recursive conversion: %w", err)
 	}
 
@@ -463,7 +476,7 @@ func (d *Decomposer) convertTrees(
 // The function returns the list of the components' descendants to keep recursing.
 // An empty list means the component is a leaf and no more recursion is needed.
 func (d *Decomposer) convertTree(
-	nl *sbom.NodeList, components []string, trees *map[string][]string, seen *map[string]struct{}, //nolint:gocritic
+	nl *sbom.NodeList, components []string, trees *map[string][]string, sumHashes map[string][]string, seen *map[string]struct{}, //nolint:gocritic
 ) error {
 	// Cycle all the components
 	for _, component := range components {
@@ -507,7 +520,7 @@ func (d *Decomposer) convertTree(
 					Identifiers: map[int32]string{
 						int32(sbom.SoftwareIdentifierType_PURL): goStringToPurl(subcomponent),
 					},
-					Hashes: map[int32]string{},
+					Hashes: goSumToHashes(subcomponent, sumHashes),
 					PrimaryPurpose: []sbom.Purpose{
 						sbom.Purpose_LIBRARY,
 					},
@@ -522,11 +535,32 @@ func (d *Decomposer) convertTree(
 
 		(*seen)[component] = struct{}{}
 		// Recurse to the subcomponent's children
-		if err := d.convertTree(nl, (*trees)[component], trees, seen); err != nil {
+		if err := d.convertTree(nl, (*trees)[component], trees, sumHashes, seen); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// goSumToHashes converts go.sum hash entries for a module into protobom hashes.
+// go.sum uses "h1:" prefix for SHA-256 hashes, base64-encoded.
+func goSumToHashes(modKey string, sumHashes map[string][]string) map[int32]string {
+	hashes := make(map[int32]string)
+	if sumHashes == nil {
+		return hashes
+	}
+	for _, h := range sumHashes[modKey] {
+		if !strings.HasPrefix(h, "h1:") {
+			continue
+		}
+		b64 := strings.TrimPrefix(h, "h1:")
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			continue
+		}
+		hashes[int32(sbom.HashAlgorithm_SHA256)] = hex.EncodeToString(decoded)
+	}
+	return hashes
 }
 
 // goStringToPurl converts a graph entry to a package url

--- a/source/golang/decomposer_test.go
+++ b/source/golang/decomposer_test.go
@@ -5,12 +5,17 @@ package golang
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/sumdb/dirhash"
 
 	api "github.com/carabiner-dev/unpack/api/v1"
 )
@@ -91,7 +96,7 @@ func TestBuildDependencyTree(t *testing.T) {
 	modFile, err := d.parseLocalGoMod("testdata/simple/go.mod")
 	require.NoError(t, err)
 
-	trees, err := d.buildDependencyTree(modFile, "testdata/simple/go.mod", &defaultOptions)
+	trees, _, err := d.buildDependencyTree(modFile, "testdata/simple/go.mod", &defaultOptions)
 	require.NoError(t, err)
 	require.NotNil(t, trees)
 
@@ -109,7 +114,7 @@ func TestBuildDependencyTreeWithReplace(t *testing.T) {
 	modFile, err := d.parseLocalGoMod("testdata/with-replace/go.mod")
 	require.NoError(t, err)
 
-	trees, err := d.buildDependencyTree(modFile, "testdata/with-replace/go.mod", &defaultOptions)
+	trees, _, err := d.buildDependencyTree(modFile, "testdata/with-replace/go.mod", &defaultOptions)
 	require.NoError(t, err)
 	require.NotNil(t, trees)
 
@@ -240,7 +245,7 @@ func TestConvertTree(t *testing.T) {
 			},
 		})
 
-		err := d.convertTree(nl, []string{"github.com/knqyf263/go-rpmdb@v0.1.1"}, trees, &map[string]struct{}{})
+		err := d.convertTree(nl, []string{"github.com/knqyf263/go-rpmdb@v0.1.1"}, trees, nil, &map[string]struct{}{})
 		require.NoError(t, err)
 
 		// This is the list of all the entries from the expected nodes
@@ -285,12 +290,12 @@ func TestConvertTree(t *testing.T) {
 	})
 
 	t.Run("no-deps", func(t *testing.T) {
-		err := d.convertTree(sbom.NewNodeList(), []string{"invalid"}, trees, &map[string]struct{}{})
+		err := d.convertTree(sbom.NewNodeList(), []string{"invalid"}, trees, nil, &map[string]struct{}{})
 		require.Error(t, err)
 	})
 
 	t.Run("no-node", func(t *testing.T) {
-		err := d.convertTree(sbom.NewNodeList(), []string{"sigs.k8s.io/bom"}, trees, &map[string]struct{}{})
+		err := d.convertTree(sbom.NewNodeList(), []string{"sigs.k8s.io/bom"}, trees, nil, &map[string]struct{}{})
 		require.Error(t, err)
 	})
 }
@@ -328,7 +333,7 @@ func TestConvertTrees(t *testing.T) {
 	t.Run("two-branches", func(t *testing.T) {
 		t.Parallel()
 		root := "sigs.k8s.io/bom"
-		nl, err := d.convertTrees(&api.DecomposerOptions{}, root, trees, "")
+		nl, err := d.convertTrees(&api.DecomposerOptions{}, root, trees, "", nil)
 		require.NoError(t, err)
 		require.NotNil(t, nl)
 
@@ -408,4 +413,49 @@ func TestGoStringToPurl(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestGoSumHashMatchesProxy(t *testing.T) {
+	t.Parallel()
+
+	// Extract the dependency from testdata/simple using our decomposer
+	d := New()
+	nl, err := d.Extract(&api.DecomposerOptions{WorkDir: "testdata/simple"})
+	require.NoError(t, err)
+
+	// Find the node for github.com/google/uuid
+	nodes := nl.GetNodesByIdentifier("purl", "pkg:golang/github.com/google/uuid@v1.3.0")
+	require.Len(t, nodes, 1, "should find google/uuid node")
+	node := nodes[0]
+
+	// The node should have a hash from go.sum
+	goSumHash, ok := node.GetHashes()[int32(sbom.HashAlgorithm_SHA256)]
+	require.True(t, ok, "node should have a SHA-256 hash from go.sum")
+	require.NotEmpty(t, goSumHash)
+
+	// Download the module zip from the Go proxy
+	resp, err := http.Get("https://proxy.golang.org/github.com/google/uuid/@v/v1.3.0.zip") //nolint:noctx
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	zipData, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// Write to temp file so dirhash.HashZip can process it
+	zipPath := filepath.Join(t.TempDir(), "uuid.zip")
+	require.NoError(t, os.WriteFile(zipPath, zipData, 0o600))
+
+	// Compute the dirhash (h1:) — the same algorithm go.sum uses
+	h1Hash, err := dirhash.HashZip(zipPath, dirhash.Hash1)
+	require.NoError(t, err)
+
+	// Convert the dirhash through our goSumToHashes to get the hex digest
+	expectedHashes := goSumToHashes("key", map[string][]string{
+		"key": {h1Hash},
+	})
+	expectedHex := expectedHashes[int32(sbom.HashAlgorithm_SHA256)]
+
+	require.Equal(t, expectedHex, goSumHash,
+		"hash on node should match dirhash computed from proxy zip")
 }

--- a/source/maven/decomposer.go
+++ b/source/maven/decomposer.go
@@ -74,7 +74,10 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 		return nil, fmt.Errorf("building dependency tree: %w", err)
 	}
 
-	// 5. Convert to NodeList
+	// 5. Fetch artifact hashes in parallel
+	dt.FetchHashes()
+
+	// 6. Convert to NodeList
 	nl, err := dt.ToNodeList(opts)
 	if err != nil {
 		return nil, fmt.Errorf("converting to nodelist: %w", err)

--- a/source/maven/decomposer.go
+++ b/source/maven/decomposer.go
@@ -30,6 +30,7 @@ type Options struct {
 	IncludeTest     bool   // Include test-scoped dependencies (default: false)
 	IncludeProvided bool   // Include provided-scoped dependencies (default: false)
 	IncludeOptional bool   // Include optional dependencies (default: false)
+	ModernHashes    bool   // Download artifacts and compute SHA-256 and SHA-512 hashes
 }
 
 var defaultOptions = Options{

--- a/source/maven/pom.go
+++ b/source/maven/pom.go
@@ -83,6 +83,9 @@ const (
 	ScopeProvided = "provided"
 	ScopeSystem   = "system"
 	ScopeImport   = "import"
+
+	// DefaultType is the default Maven artifact type.
+	DefaultType = "jar"
 )
 
 // IsOptional returns true if the dependency is marked optional.
@@ -101,7 +104,7 @@ func (d *Dependency) EffectiveScope() string {
 // EffectiveType returns the dependency's type, defaulting to "jar".
 func (d *Dependency) EffectiveType() string {
 	if d.Type == "" {
-		return "jar"
+		return DefaultType
 	}
 	return d.Type
 }

--- a/source/maven/resolver.go
+++ b/source/maven/resolver.go
@@ -4,12 +4,15 @@
 package maven
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/carabiner-dev/hasher"
 	khttp "sigs.k8s.io/release-utils/http"
 )
 
@@ -113,9 +116,9 @@ type mavenMetadata struct {
 // snapshotMetadata represents the version-level maven-metadata.xml for SNAPSHOT versions.
 // It contains the timestamp and build number needed to construct the actual artifact filename.
 type snapshotMetadata struct {
-	Timestamp   string                   `xml:"versioning>snapshot>timestamp"`
-	BuildNumber string                   `xml:"versioning>snapshot>buildNumber"`
-	Versions    []snapshotVersionEntry    `xml:"versioning>snapshotVersions>snapshotVersion"`
+	Timestamp   string                 `xml:"versioning>snapshot>timestamp"`
+	BuildNumber string                 `xml:"versioning>snapshot>buildNumber"`
+	Versions    []snapshotVersionEntry `xml:"versioning>snapshotVersions>snapshotVersion"`
 }
 
 // snapshotVersionEntry is a single entry in the snapshotVersions list.
@@ -190,7 +193,7 @@ func (r *Resolver) FetchAvailableVersions(groupID, artifactID string) ([]string,
 }
 
 // artifactURL constructs the Maven repository URL for an artifact.
-func (r *Resolver) artifactURL(coord Coordinate) string {
+func (r *Resolver) artifactURL(coord *Coordinate) string {
 	groupPath := strings.ReplaceAll(coord.GroupID, ".", "/")
 	return fmt.Sprintf("%s/%s/%s/%s/%s", r.RepoURL, groupPath, coord.ArtifactID, coord.Version, coord.ArtifactFilename())
 }
@@ -217,8 +220,8 @@ func (r *Resolver) FetchAllArtifactHashes(coords []Coordinate) map[string]map[st
 
 	// Build the list of URLs to fetch: 2 per coordinate (sha1, sha256)
 	urls := make([]string, 0, len(coords)*len(supportedHashes))
-	for _, c := range coords {
-		base := r.artifactURL(c)
+	for i := range coords {
+		base := r.artifactURL(&coords[i])
 		for _, h := range supportedHashes {
 			urls = append(urls, base+h.suffix)
 		}
@@ -244,6 +247,60 @@ func (r *Resolver) FetchAllArtifactHashes(coords []Coordinate) map[string]map[st
 			if digest != "" {
 				hashes[h.algo] = digest
 			}
+		}
+		if len(hashes) > 0 {
+			result[cacheKey(c.GroupID, c.ArtifactID, c.Version)] = hashes
+		}
+	}
+
+	return result
+}
+
+// ComputeArtifactHashes downloads artifacts in parallel and computes
+// SHA-256 and SHA-512 digests locally. It returns a map keyed by
+// "groupId:artifactId:version" containing algo->hex digest maps.
+func (r *Resolver) ComputeArtifactHashes(coords []Coordinate) map[string]map[string]string {
+	if len(coords) == 0 {
+		return nil
+	}
+
+	// Build artifact URLs
+	urls := make([]string, len(coords))
+	for i := range coords {
+		urls[i] = r.artifactURL(&coords[i])
+	}
+
+	// Download all artifacts in parallel
+	bodies, errs := r.Agent.GetGroup(urls)
+
+	// Collect downloaded bodies and their coordinates for batch hashing
+	var readers []io.Reader
+	var coordIndices []int
+	for i := range coords {
+		if errs[i] != nil || len(bodies[i]) == 0 {
+			continue
+		}
+		readers = append(readers, bytes.NewReader(bodies[i]))
+		coordIndices = append(coordIndices, i)
+	}
+
+	result := make(map[string]map[string]string, len(coords))
+	if len(readers) == 0 {
+		return result
+	}
+
+	h := hasher.New()
+	hashResults, err := h.HashReaders(readers)
+	if err != nil || hashResults == nil {
+		return result
+	}
+
+	for j, idx := range coordIndices {
+		c := coords[idx]
+		hashes := make(map[string]string, len((*hashResults)[j]))
+		for algo, digest := range (*hashResults)[j] {
+			// Store with uppercase key to match hashesForNode expectations
+			hashes[strings.ToUpper(string(algo))] = digest
 		}
 		if len(hashes) > 0 {
 			result[cacheKey(c.GroupID, c.ArtifactID, c.Version)] = hashes

--- a/source/maven/resolver.go
+++ b/source/maven/resolver.go
@@ -122,10 +122,10 @@ func (r *Resolver) FetchAvailableVersions(groupID, artifactID string) ([]string,
 	return meta.Versions, nil
 }
 
-// artifactURL constructs the Maven repository URL for a JAR artifact.
-func (r *Resolver) artifactURL(groupID, artifactID, version string) string {
-	groupPath := strings.ReplaceAll(groupID, ".", "/")
-	return fmt.Sprintf("%s/%s/%s/%s/%s-%s.jar", r.RepoURL, groupPath, artifactID, version, artifactID, version)
+// artifactURL constructs the Maven repository URL for an artifact.
+func (r *Resolver) artifactURL(coord Coordinate) string {
+	groupPath := strings.ReplaceAll(coord.GroupID, ".", "/")
+	return fmt.Sprintf("%s/%s/%s/%s/%s", r.RepoURL, groupPath, coord.ArtifactID, coord.Version, coord.ArtifactFilename())
 }
 
 // hashSuffix pairs a file extension with its algorithm name.
@@ -151,7 +151,7 @@ func (r *Resolver) FetchAllArtifactHashes(coords []Coordinate) map[string]map[st
 	// Build the list of URLs to fetch: 2 per coordinate (sha1, sha256)
 	urls := make([]string, 0, len(coords)*len(supportedHashes))
 	for _, c := range coords {
-		base := r.artifactURL(c.GroupID, c.ArtifactID, c.Version)
+		base := r.artifactURL(c)
 		for _, h := range supportedHashes {
 			urls = append(urls, base+h.suffix)
 		}

--- a/source/maven/resolver.go
+++ b/source/maven/resolver.go
@@ -122,6 +122,70 @@ func (r *Resolver) FetchAvailableVersions(groupID, artifactID string) ([]string,
 	return meta.Versions, nil
 }
 
+// artifactURL constructs the Maven repository URL for a JAR artifact.
+func (r *Resolver) artifactURL(groupID, artifactID, version string) string {
+	groupPath := strings.ReplaceAll(groupID, ".", "/")
+	return fmt.Sprintf("%s/%s/%s/%s/%s-%s.jar", r.RepoURL, groupPath, artifactID, version, artifactID, version)
+}
+
+// hashSuffix pairs a file extension with its algorithm name.
+type hashSuffix struct {
+	suffix string
+	algo   string
+}
+
+// supportedHashes lists the hash files we attempt to fetch from the repo.
+var supportedHashes = []hashSuffix{
+	{".sha1", "SHA1"},
+	{".sha256", "SHA256"},
+}
+
+// FetchAllArtifactHashes fetches SHA-1 and SHA-256 checksums for multiple
+// artifacts in parallel using the Agent's GetGroup. It returns a map keyed
+// by "groupId:artifactId:version" containing algo->digest maps.
+func (r *Resolver) FetchAllArtifactHashes(coords []Coordinate) map[string]map[string]string {
+	if len(coords) == 0 {
+		return nil
+	}
+
+	// Build the list of URLs to fetch: 2 per coordinate (sha1, sha256)
+	urls := make([]string, 0, len(coords)*len(supportedHashes))
+	for _, c := range coords {
+		base := r.artifactURL(c.GroupID, c.ArtifactID, c.Version)
+		for _, h := range supportedHashes {
+			urls = append(urls, base+h.suffix)
+		}
+	}
+
+	// Fetch all hash files in parallel
+	bodies, errs := r.Agent.GetGroup(urls)
+
+	// Parse results back into per-coordinate hash maps
+	result := make(map[string]map[string]string, len(coords))
+	for i, c := range coords {
+		hashes := make(map[string]string)
+		for j, h := range supportedHashes {
+			idx := i*len(supportedHashes) + j
+			if errs[idx] != nil || len(bodies[idx]) == 0 {
+				continue
+			}
+			digest := strings.TrimSpace(string(bodies[idx]))
+			// Some repos append the filename after the hash
+			if sp := strings.IndexByte(digest, ' '); sp > 0 {
+				digest = digest[:sp]
+			}
+			if digest != "" {
+				hashes[h.algo] = digest
+			}
+		}
+		if len(hashes) > 0 {
+			result[cacheKey(c.GroupID, c.ArtifactID, c.Version)] = hashes
+		}
+	}
+
+	return result
+}
+
 // ResolveVersionRange resolves a version range to a concrete version.
 func (r *Resolver) ResolveVersionRange(groupID, artifactID, rangeSpec string) (string, error) {
 	vr, err := ParseVersionRange(rangeSpec)

--- a/source/maven/resolver.go
+++ b/source/maven/resolver.go
@@ -86,9 +86,12 @@ func (r *Resolver) FetchPOM(groupID, artifactID, version string) (*POM, error) {
 }
 
 // pomURL constructs the Maven repository URL for a POM file.
+// For SNAPSHOT versions, it resolves the actual timestamped filename
+// via the version-level maven-metadata.xml.
 func (r *Resolver) pomURL(groupID, artifactID, version string) string {
 	groupPath := strings.ReplaceAll(groupID, ".", "/")
-	return fmt.Sprintf("%s/%s/%s/%s/%s-%s.pom", r.RepoURL, groupPath, artifactID, version, artifactID, version)
+	fileVersion := r.ResolveSnapshotVersion(groupID, artifactID, version, "pom", "")
+	return fmt.Sprintf("%s/%s/%s/%s/%s-%s.pom", r.RepoURL, groupPath, artifactID, version, artifactID, fileVersion)
 }
 
 // metadataURL constructs the URL for maven-metadata.xml.
@@ -97,13 +100,77 @@ func (r *Resolver) metadataURL(groupID, artifactID string) string {
 	return fmt.Sprintf("%s/%s/%s/maven-metadata.xml", r.RepoURL, groupPath, artifactID)
 }
 
-// mavenMetadata represents the structure of maven-metadata.xml.
+// mavenMetadata represents the structure of the artifact-level maven-metadata.xml
+// (lists all available versions).
 type mavenMetadata struct {
 	GroupID    string   `xml:"groupId"`
 	ArtifactID string   `xml:"artifactId"`
 	Latest     string   `xml:"versioning>latest"`
 	Release    string   `xml:"versioning>release"`
 	Versions   []string `xml:"versioning>versions>version"`
+}
+
+// snapshotMetadata represents the version-level maven-metadata.xml for SNAPSHOT versions.
+// It contains the timestamp and build number needed to construct the actual artifact filename.
+type snapshotMetadata struct {
+	Timestamp   string                   `xml:"versioning>snapshot>timestamp"`
+	BuildNumber string                   `xml:"versioning>snapshot>buildNumber"`
+	Versions    []snapshotVersionEntry    `xml:"versioning>snapshotVersions>snapshotVersion"`
+}
+
+// snapshotVersionEntry is a single entry in the snapshotVersions list.
+type snapshotVersionEntry struct {
+	Classifier string `xml:"classifier"`
+	Extension  string `xml:"extension"`
+	Value      string `xml:"value"`
+}
+
+// isSnapshot returns true if the version string ends with -SNAPSHOT.
+func isSnapshot(version string) bool {
+	return strings.HasSuffix(strings.ToUpper(version), "-SNAPSHOT")
+}
+
+// versionMetadataURL constructs the URL for the version-level maven-metadata.xml.
+func (r *Resolver) versionMetadataURL(groupID, artifactID, version string) string {
+	groupPath := strings.ReplaceAll(groupID, ".", "/")
+	return fmt.Sprintf("%s/%s/%s/%s/maven-metadata.xml", r.RepoURL, groupPath, artifactID, version)
+}
+
+// ResolveSnapshotVersion fetches the version-level maven-metadata.xml for a
+// SNAPSHOT version and returns the resolved timestamped version string
+// (e.g. "1.0-20260418.130000-2") for the given extension and classifier.
+// Returns the original version unchanged if the metadata cannot be fetched.
+func (r *Resolver) ResolveSnapshotVersion(groupID, artifactID, version, ext, classifier string) string {
+	if !isSnapshot(version) {
+		return version
+	}
+
+	url := r.versionMetadataURL(groupID, artifactID, version)
+	data, err := r.Agent.Get(url)
+	if err != nil {
+		return version
+	}
+
+	var meta snapshotMetadata
+	if err := xml.Unmarshal(data, &meta); err != nil {
+		return version
+	}
+
+	// Try to find a matching snapshotVersion entry
+	for _, sv := range meta.Versions {
+		if sv.Extension == ext && sv.Classifier == classifier {
+			return sv.Value
+		}
+	}
+
+	// Fallback: construct from timestamp and build number
+	if meta.Timestamp != "" && meta.BuildNumber != "" {
+		base := strings.TrimSuffix(version, "-SNAPSHOT")
+		base = strings.TrimSuffix(base, "-snapshot")
+		return fmt.Sprintf("%s-%s-%s", base, meta.Timestamp, meta.BuildNumber)
+	}
+
+	return version
 }
 
 // FetchAvailableVersions fetches maven-metadata.xml and returns all versions.

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -444,8 +444,16 @@ func (dt *DependencyTree) ToNodeList(opts *api.DecomposerOptions) (*sbom.NodeLis
 		nodeMap[rd.Coordinate.String()] = node
 	}
 
-	// Create edges
-	for parentCoord, children := range dt.edges {
+	// Create edges in BFS order from root so that parent nodes are always
+	// added to the NodeList before their children (RelateNodeAtID requires
+	// the parent to already exist in the NodeList).
+	queue := []string{rootCoord.String()}
+	visited := map[string]struct{}{rootCoord.String(): {}}
+	for len(queue) > 0 {
+		parentCoord := queue[0]
+		queue = queue[1:]
+
+		children := dt.edges[parentCoord]
 		parentNode, ok := nodeMap[parentCoord]
 		if !ok {
 			continue
@@ -457,10 +465,14 @@ func (dt *DependencyTree) ToNodeList(opts *api.DecomposerOptions) (*sbom.NodeLis
 				continue
 			}
 
-			// Determine edge type based on the child's scope
 			edgeType := dt.edgeTypeForCoord(childCoord)
 			if err := nl.RelateNodeAtID(childNode, parentNode.GetId(), edgeType); err != nil {
 				return nil, fmt.Errorf("relating %s to %s: %w", childCoord, parentCoord, err)
+			}
+
+			if _, seen := visited[childCoord]; !seen {
+				visited[childCoord] = struct{}{}
+				queue = append(queue, childCoord)
 			}
 		}
 	}

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -165,6 +165,8 @@ func (dt *DependencyTree) Build() error {
 			GroupID:    dep.GroupID,
 			ArtifactID: dep.ArtifactID,
 			Version:    version,
+			Type:       dep.EffectiveType(),
+			Classifier: dep.Classifier,
 		}
 
 		// Fetch the dependency's POM for license info and transitive deps
@@ -443,10 +445,10 @@ func (dt *DependencyTree) ToNodeList(opts *api.DecomposerOptions) (*sbom.NodeLis
 // createDependencyNode creates a protobom Node for a resolved dependency.
 func (dt *DependencyTree) createDependencyNode(rd *ResolvedDependency) *sbom.Node {
 	groupPath := strings.ReplaceAll(rd.Coordinate.GroupID, ".", "/")
-	downloadURL := fmt.Sprintf("%s/%s/%s/%s/%s-%s.jar",
+	downloadURL := fmt.Sprintf("%s/%s/%s/%s/%s",
 		defaultRepoURL, groupPath,
 		rd.Coordinate.ArtifactID, rd.Coordinate.Version,
-		rd.Coordinate.ArtifactID, rd.Coordinate.Version,
+		rd.Coordinate.ArtifactFilename(),
 	)
 
 	node := &sbom.Node{

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -33,6 +33,8 @@ func (rd *ResolvedDependency) hashesForNode() map[int32]string {
 			m[int32(sbom.HashAlgorithm_SHA1)] = digest
 		case "SHA256":
 			m[int32(sbom.HashAlgorithm_SHA256)] = digest
+		case "SHA512":
+			m[int32(sbom.HashAlgorithm_SHA512)] = digest
 		}
 	}
 	return m
@@ -336,7 +338,7 @@ func (dt *DependencyTree) FetchHashes() {
 		}
 		ext := rd.Coordinate.Type
 		if ext == "" {
-			ext = "jar"
+			ext = DefaultType
 		}
 		rd.Coordinate.SnapshotVersion = dt.resolver.ResolveSnapshotVersion(
 			rd.Coordinate.GroupID, rd.Coordinate.ArtifactID,
@@ -349,8 +351,22 @@ func (dt *DependencyTree) FetchHashes() {
 		return
 	}
 
-	// Fetch all hashes in parallel
+	// Fetch all checksum file hashes in parallel
 	allHashes := dt.resolver.FetchAllArtifactHashes(coords)
+
+	// If ModernHashes is enabled, download artifacts and compute SHA-256/SHA-512
+	if dt.opts.ModernHashes {
+		computed := dt.resolver.ComputeArtifactHashes(coords)
+		for key, hashes := range computed {
+			if existing, ok := allHashes[key]; ok {
+				for algo, digest := range hashes {
+					existing[algo] = digest
+				}
+			} else {
+				allHashes[key] = hashes
+			}
+		}
+	}
 
 	// Store the hashes back on the resolved dependencies
 	for _, rd := range dt.resolved {
@@ -470,7 +486,7 @@ func (dt *DependencyTree) createDependencyNode(rd *ResolvedDependency) *sbom.Nod
 		Identifiers: map[int32]string{
 			int32(sbom.SoftwareIdentifierType_PURL): rd.Coordinate.PURL(),
 		},
-		Hashes:         rd.hashesForNode(),
+		Hashes: rd.hashesForNode(),
 		PrimaryPurpose: []sbom.Purpose{
 			sbom.Purpose_LIBRARY,
 		},

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -20,7 +20,22 @@ type ResolvedDependency struct {
 	Scope      string
 	Optional   bool
 	Licenses   []License
+	Hashes     map[string]string // algo name -> hex digest (e.g. "SHA1" -> "abc123")
 	Depth      int
+}
+
+// hashesForNode converts the string-keyed hashes to protobom hash algorithm keys.
+func (rd *ResolvedDependency) hashesForNode() map[int32]string {
+	m := make(map[int32]string, len(rd.Hashes))
+	for algo, digest := range rd.Hashes {
+		switch algo {
+		case "SHA1":
+			m[int32(sbom.HashAlgorithm_SHA1)] = digest
+		case "SHA256":
+			m[int32(sbom.HashAlgorithm_SHA256)] = digest
+		}
+	}
+	return m
 }
 
 // DependencyTree builds the resolved dependency graph from a Maven POM.
@@ -300,6 +315,40 @@ func scopeTransitivity(parentScope, depScope string) string {
 	}
 }
 
+// FetchHashes fetches artifact checksums for all resolved dependencies
+// in parallel and stores them in the resolved dependency entries.
+func (dt *DependencyTree) FetchHashes() {
+	if dt.resolver == nil {
+		return
+	}
+
+	rootKey := dt.rootPOM.EffectiveGroupID() + ":" + dt.rootPOM.ArtifactID
+
+	// Collect coordinates of all non-root resolved dependencies
+	coords := make([]Coordinate, 0, len(dt.resolved))
+	for key, rd := range dt.resolved {
+		if key == rootKey {
+			continue
+		}
+		coords = append(coords, rd.Coordinate)
+	}
+
+	if len(coords) == 0 {
+		return
+	}
+
+	// Fetch all hashes in parallel
+	allHashes := dt.resolver.FetchAllArtifactHashes(coords)
+
+	// Store the hashes back on the resolved dependencies
+	for _, rd := range dt.resolved {
+		key := rd.Coordinate.GroupID + ":" + rd.Coordinate.ArtifactID + ":" + rd.Coordinate.Version
+		if h, ok := allHashes[key]; ok {
+			rd.Hashes = h
+		}
+	}
+}
+
 // ToNodeList converts the resolved dependency tree to a protobom NodeList.
 func (dt *DependencyTree) ToNodeList(opts *api.DecomposerOptions) (*sbom.NodeList, error) {
 	nl := sbom.NewNodeList()
@@ -409,7 +458,7 @@ func (dt *DependencyTree) createDependencyNode(rd *ResolvedDependency) *sbom.Nod
 		Identifiers: map[int32]string{
 			int32(sbom.SoftwareIdentifierType_PURL): rd.Coordinate.PURL(),
 		},
-		Hashes: map[int32]string{},
+		Hashes:         rd.hashesForNode(),
 		PrimaryPurpose: []sbom.Purpose{
 			sbom.Purpose_LIBRARY,
 		},

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -167,6 +167,7 @@ func (dt *DependencyTree) Build() error {
 			Version:    version,
 			Type:       dep.EffectiveType(),
 			Classifier: dep.Classifier,
+			RepoURL:    dt.nonDefaultRepoURL(),
 		}
 
 		// Fetch the dependency's POM for license info and transitive deps
@@ -471,6 +472,15 @@ func (dt *DependencyTree) createDependencyNode(rd *ResolvedDependency) *sbom.Nod
 	}
 
 	return node
+}
+
+// nonDefaultRepoURL returns the resolver's repo URL if it differs from Maven Central,
+// or empty string otherwise.
+func (dt *DependencyTree) nonDefaultRepoURL() string {
+	if dt.resolver != nil && dt.resolver.RepoURL != defaultRepoURL {
+		return dt.resolver.RepoURL
+	}
+	return ""
 }
 
 // edgeTypeForCoord returns the appropriate edge type for a dependency.

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -327,12 +327,21 @@ func (dt *DependencyTree) FetchHashes() {
 
 	rootKey := dt.rootPOM.EffectiveGroupID() + ":" + dt.rootPOM.ArtifactID
 
-	// Collect coordinates of all non-root resolved dependencies
+	// Collect coordinates of all non-root resolved dependencies,
+	// resolving SNAPSHOT versions to their timestamped filenames.
 	coords := make([]Coordinate, 0, len(dt.resolved))
 	for key, rd := range dt.resolved {
 		if key == rootKey {
 			continue
 		}
+		ext := rd.Coordinate.Type
+		if ext == "" {
+			ext = "jar"
+		}
+		rd.Coordinate.SnapshotVersion = dt.resolver.ResolveSnapshotVersion(
+			rd.Coordinate.GroupID, rd.Coordinate.ArtifactID,
+			rd.Coordinate.Version, ext, rd.Coordinate.Classifier,
+		)
 		coords = append(coords, rd.Coordinate)
 	}
 

--- a/source/maven/version.go
+++ b/source/maven/version.go
@@ -38,6 +38,19 @@ func (c *Coordinate) Key() string {
 	return c.GroupID + ":" + c.ArtifactID
 }
 
+// ArtifactFilename returns the Maven artifact filename following the convention:
+// {artifactId}-{version}[-{classifier}].{type}
+func (c *Coordinate) ArtifactFilename() string {
+	ext := c.Type
+	if ext == "" {
+		ext = "jar"
+	}
+	if c.Classifier != "" {
+		return fmt.Sprintf("%s-%s-%s.%s", c.ArtifactID, c.Version, c.Classifier, ext)
+	}
+	return fmt.Sprintf("%s-%s.%s", c.ArtifactID, c.Version, ext)
+}
+
 // qualifierRank returns the ordering rank for known Maven qualifiers.
 // Lower values sort earlier. Unknown qualifiers get a high rank.
 func qualifierRank(q string) int {

--- a/source/maven/version.go
+++ b/source/maven/version.go
@@ -35,7 +35,7 @@ func (c *Coordinate) PURL() string {
 	}
 
 	var qualifiers []string
-	if c.Type != "" && c.Type != "jar" {
+	if c.Type != "" && c.Type != DefaultType {
 		qualifiers = append(qualifiers, "type="+c.Type)
 	}
 	if c.Classifier != "" {
@@ -62,7 +62,7 @@ func (c *Coordinate) Key() string {
 func (c *Coordinate) ArtifactFilename() string {
 	ext := c.Type
 	if ext == "" {
-		ext = "jar"
+		ext = DefaultType
 	}
 	version := c.SnapshotVersion
 	if version == "" {

--- a/source/maven/version.go
+++ b/source/maven/version.go
@@ -17,6 +17,7 @@ type Coordinate struct {
 	Version    string
 	Classifier string
 	Type       string
+	RepoURL    string // non-empty only when different from Maven Central
 }
 
 // String returns "groupId:artifactId:version".
@@ -24,11 +25,26 @@ func (c *Coordinate) String() string {
 	return fmt.Sprintf("%s:%s:%s", c.GroupID, c.ArtifactID, c.Version)
 }
 
-// PURL returns the Package URL for this coordinate.
+// PURL returns the Package URL for this coordinate, including qualifiers
+// for type (if not jar), classifier (if set), and repository_url (if set).
 func (c *Coordinate) PURL() string {
 	purl := fmt.Sprintf("pkg:maven/%s/%s", c.GroupID, c.ArtifactID)
 	if c.Version != "" {
 		purl += "@" + c.Version
+	}
+
+	var qualifiers []string
+	if c.Type != "" && c.Type != "jar" {
+		qualifiers = append(qualifiers, "type="+c.Type)
+	}
+	if c.Classifier != "" {
+		qualifiers = append(qualifiers, "classifier="+c.Classifier)
+	}
+	if c.RepoURL != "" {
+		qualifiers = append(qualifiers, "repository_url="+c.RepoURL)
+	}
+	if len(qualifiers) > 0 {
+		purl += "?" + strings.Join(qualifiers, "&")
 	}
 	return purl
 }

--- a/source/maven/version.go
+++ b/source/maven/version.go
@@ -12,12 +12,13 @@ import (
 
 // Coordinate uniquely identifies a Maven artifact.
 type Coordinate struct {
-	GroupID    string
-	ArtifactID string
-	Version    string
-	Classifier string
-	Type       string
-	RepoURL    string // non-empty only when different from Maven Central
+	GroupID         string
+	ArtifactID      string
+	Version         string
+	Classifier      string
+	Type            string
+	RepoURL         string // non-empty only when different from Maven Central
+	SnapshotVersion string // resolved timestamped version for SNAPSHOTs (e.g. "1.0-20260418.130000-2")
 }
 
 // String returns "groupId:artifactId:version".
@@ -56,15 +57,21 @@ func (c *Coordinate) Key() string {
 
 // ArtifactFilename returns the Maven artifact filename following the convention:
 // {artifactId}-{version}[-{classifier}].{type}
+// For SNAPSHOT artifacts with a resolved timestamped version, it uses the
+// snapshot version (e.g. "1.0-20260418.130000-2") instead of "1.0-SNAPSHOT".
 func (c *Coordinate) ArtifactFilename() string {
 	ext := c.Type
 	if ext == "" {
 		ext = "jar"
 	}
-	if c.Classifier != "" {
-		return fmt.Sprintf("%s-%s-%s.%s", c.ArtifactID, c.Version, c.Classifier, ext)
+	version := c.SnapshotVersion
+	if version == "" {
+		version = c.Version
 	}
-	return fmt.Sprintf("%s-%s.%s", c.ArtifactID, c.Version, ext)
+	if c.Classifier != "" {
+		return fmt.Sprintf("%s-%s-%s.%s", c.ArtifactID, version, c.Classifier, ext)
+	}
+	return fmt.Sprintf("%s-%s.%s", c.ArtifactID, version, ext)
 }
 
 // qualifierRank returns the ordering rank for known Maven qualifiers.

--- a/source/maven/version_test.go
+++ b/source/maven/version_test.go
@@ -18,6 +18,11 @@ func TestCoordinatePURL(t *testing.T) {
 	}{
 		{"basic", Coordinate{GroupID: "com.google.guava", ArtifactID: "guava", Version: "33.0.0-jre"}, "pkg:maven/com.google.guava/guava@33.0.0-jre"},
 		{"no version", Coordinate{GroupID: "g", ArtifactID: "a"}, "pkg:maven/g/a"},
+		{"with type", Coordinate{GroupID: "g", ArtifactID: "a", Version: "1.0", Type: "war"}, "pkg:maven/g/a@1.0?type=war"},
+		{"jar type omitted", Coordinate{GroupID: "g", ArtifactID: "a", Version: "1.0", Type: "jar"}, "pkg:maven/g/a@1.0"},
+		{"with classifier", Coordinate{GroupID: "g", ArtifactID: "a", Version: "1.0", Classifier: "sources"}, "pkg:maven/g/a@1.0?classifier=sources"},
+		{"with repo url", Coordinate{GroupID: "g", ArtifactID: "a", Version: "1.0", RepoURL: "https://repo.example.com/maven2"}, "pkg:maven/g/a@1.0?repository_url=https://repo.example.com/maven2"},
+		{"all qualifiers", Coordinate{GroupID: "g", ArtifactID: "a", Version: "1.0", Type: "aar", Classifier: "debug", RepoURL: "https://example.com/repo"}, "pkg:maven/g/a@1.0?type=aar&classifier=debug&repository_url=https://example.com/repo"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This pull request introduces significant improvements to the Go and Maven decomposers, focusing on more accurate and complete dependency metadata—especially around hash extraction and SNAPSHOT version resolution. For Go, it now parses and attaches SHA-256 hashes from `go.sum` to SBOM nodes, and for Maven, it correctly resolves SNAPSHOT artifact filenames using version-level metadata. Several tests are updated and extended to verify these enhancements.

**Go decomposer improvements:**

* The `buildDependencyTree` and related methods now extract SHA-256 hashes from `go.sum` and attach them to SBOM nodes, ensuring that each dependency node includes its verified hash. This is handled by the new `goSumToHashes` function and changes to the recursive tree conversion logic. [[1]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL79-R81) [[2]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL90-R92) [[3]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL149-R161) [[4]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL171-R182) [[5]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fR223-R225) [[6]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL227-R240) [[7]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL398-R411) [[8]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL417-R430) [[9]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL466-R479) [[10]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL510-R523) [[11]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL525-R565)
* The Go decomposer test suite is updated to reflect the new function signatures and includes a new integration test that verifies hashes extracted from `go.sum` match those computed from the Go proxy's module zip. [[1]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336L94-R99) [[2]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336L112-R117) [[3]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336L243-R248) [[4]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336L288-R298) [[5]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336L331-R336) [[6]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336R417-R461)

**Maven decomposer improvements:**

* The Maven resolver now resolves SNAPSHOT artifact filenames by parsing the version-level `maven-metadata.xml`, ensuring correct artifact download URLs for SNAPSHOT dependencies. This is achieved via the new `ResolveSnapshotVersion` logic and supporting data structures. [[1]](diffhunk://#diff-aa7d5cd38f2691a04ebedf48a416cfcffba03377891d52c2c0ab98d91f92a340R92-R97) [[2]](diffhunk://#diff-aa7d5cd38f2691a04ebedf48a416cfcffba03377891d52c2c0ab98d91f92a340L100-R107) [[3]](diffhunk://#diff-aa7d5cd38f2691a04ebedf48a416cfcffba03377891d52c2c0ab98d91f92a340R116-R178)
* The Maven decomposer now triggers parallel fetching of artifact hashes before converting the dependency tree to a NodeList, improving completeness for SBOM generation.
* The default artifact type handling is refactored to use a constant, and the `EffectiveType` method is updated for clarity. [[1]](diffhunk://#diff-634e5862bcad0fc0b8860e56d8c36418a07b34bd3e974fa5d7d86dea59fc0a26R86-R88) [[2]](diffhunk://#diff-634e5862bcad0fc0b8860e56d8c36418a07b34bd3e974fa5d7d86dea59fc0a26L104-R107)

**Other codebase improvements:**

* Necessary imports are added for base64/hex encoding (Go) and for artifact hash computation and HTTP/file operations (Maven). [[1]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fR9-R10) [[2]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336R8-R18) [[3]](diffhunk://#diff-aa7d5cd38f2691a04ebedf48a416cfcffba03377891d52c2c0ab98d91f92a340R7-R15)
* The Maven decomposer's options struct is extended to allow for optional artifact hash computation.