### PR TITLE
Add decomposer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,17 @@ unpack ls --format=json /path/to/project
 unpack ls --ignore "*/testdata/*" --ignore "temp/" .
 ```
 
-## Supported Platforms
+## Supported Ecosystems
 
-Unpack currently supports dependency extraction for the following ecosystems:
+Unpack includes decomposers for four package ecosystems. See the
+[decomposer documentation](docs/decomposers/README.md) for details.
 
-- **Go Modules** (`go.mod`)
-- **Rust Cargo** (`Cargo.lock`)
-- **NPM** (`package-lock.json`)
+| Ecosystem | Lock file | Manifest | Remote enrichment |
+| --- | --- | --- | --- |
+| [Go](docs/decomposers/golang.md) | `go.sum` | `go.mod` | Go module proxy |
+| [Maven](docs/decomposers/maven.md) | _(none)_ | `pom.xml` | Maven Central |
+| [npm](docs/decomposers/npm.md) | `package-lock.json` | `package.json` | _(none)_ |
+| [Rust](docs/decomposers/rust.md) | `Cargo.lock` | `Cargo.toml` | crates.io API |
 
 Support for more ecosystems is planned.
 
@@ -126,7 +130,6 @@ We welcome contributions! Whether it's reporting a bug, suggesting a feature, or
 
 ## License
 
-This tool and its libraries are released under the **Apache 2.0 License**. See the [LICENSE](./LICENSE) file for more details.
-
----
-*Developed and maintained by Carabiner Systems, Inc.*
+This tool and its libraries are released under the Apache 2.0 License and copyright by
+Carabiner Systems, Inc. See the [LICENSE](./LICENSE) file for more details. Feel free to
+open issues to report problems or request features. Patches are welcome!

--- a/docs/decomposers/README.md
+++ b/docs/decomposers/README.md
@@ -1,0 +1,32 @@
+# Decomposers
+
+Unpack ships with decomposers for four package ecosystems. Each decomposer
+parses lock files and manifest files, resolves the dependency graph, and
+produces a [protobom](https://github.com/protobom/protobom) NodeList that
+can be serialized as SPDX or CycloneDX.
+
+| Ecosystem | Entry point | Lock file | Manifest | Remote enrichment |
+|-----------|------------|-----------|----------|-------------------|
+| [Go](golang.md) | `source/golang/` | `go.sum` | `go.mod` | deps.dev API + Go module proxy |
+| [Maven](maven.md) | `source/maven/` | _(none)_ | `pom.xml` | Maven Central |
+| [npm](npm.md) | `source/npm/` | `package-lock.json` | `package.json` | _(none)_ |
+| [Rust](rust.md) | `source/rust/` | `Cargo.lock` | `Cargo.toml` | crates.io API |
+
+## Common capabilities
+
+All decomposers share these behaviors:
+
+- **Pure Go** -- no external binaries are required at runtime.
+- **License normalization** -- license strings are mapped to SPDX identifiers
+  via the shared `license` package.
+- **Protobom output** -- every decomposer returns an `*sbom.NodeList` with
+  typed edges (`dependsOn`, `devDependency`, `buildDependency`, etc.).
+- **Commit hash injection** -- when `DecomposerOptions.CommitHash` is set,
+  the root node receives a VCS external reference with the SHA-1 hash.
+- **Version override** -- when `DecomposerOptions.Version` is set, the root
+  node's version and PURL are updated accordingly.
+
+## Per-decomposer docs
+
+See the individual pages linked in the table above for implementation
+details, data sources, and known limitations.

--- a/docs/decomposers/golang.md
+++ b/docs/decomposers/golang.md
@@ -1,0 +1,71 @@
+# Go Decomposer
+
+**Location:** `source/golang/`
+
+## How it works
+
+1. Parses `go.mod` to extract the module path, Go version, direct
+   dependencies, replace directives, and exclude directives.
+2. Parses `go.sum` to discover transitive dependencies and extract
+   `h1:` hashes (SHA-256 dirhash of each module zip).
+3. Fetches `go.mod` files for every resolved dependency from the
+   Go module proxy (`proxy.golang.org` by default) to reconstruct
+   the full dependency graph. Fetches run in parallel with
+   configurable concurrency.
+4. Converts the graph into a protobom NodeList.
+5. Enriches dependency nodes with license and source repository data
+   from the [deps.dev API](https://docs.deps.dev/api/v3/). For any
+   modules not found in deps.dev, falls back to downloading the
+   module zip from the proxy, extracting the LICENSE file, and
+   classifying it with `google/licenseclassifier/v2`.
+
+## Data produced per dependency
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Name | `go.mod` / graph | Module path |
+| Version | `go.mod` / `go.sum` | Resolved version after replace/exclude |
+| PURL | computed | `pkg:golang/{module}@{version}` |
+| Download URL | computed | `https://proxy.golang.org/{module}/@v/{version}.zip` |
+| Hash (SHA-256) | `go.sum` | `h1:` dirhash -- hash of the module zip's file tree, not raw bytes |
+| License | deps.dev / LICENSE file | deps.dev provides pre-classified SPDX identifiers; zip fallback uses `google/licenseclassifier/v2` |
+| Source repo | deps.dev | `ExternalReference_VCS` from deps.dev `SOURCE_REPO` link |
+
+## Special nodes
+
+- **stdlib** -- a synthetic dependency with PURL `pkg:golang/stdlib@{go version}`,
+  license `BSD-3-Clause`, added when `go.mod` declares a `go` directive.
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `IncludeGo` | `bool` | `true` | Include the stdlib node |
+| `ProxyURL` | `string` | `https://proxy.golang.org` | Go module proxy URL |
+| `HTTPClient` | `*http.Client` | _(default)_ | Custom HTTP client (for testing) |
+| `Concurrency` | `int` | `10` | Parallel proxy/deps.dev requests |
+
+## Strengths
+
+- No external tooling needed -- does not shell out to `go`.
+- Handles replace and exclude directives correctly.
+- Hashes come directly from `go.sum`, which is verified by the
+  Go checksum database.
+- Full transitive graph is reconstructed by fetching upstream `go.mod`
+  files, matching the behavior of `go mod graph`.
+- License enrichment is fast: deps.dev responses are ~500 bytes each
+  and provide pre-classified SPDX identifiers.
+- Source repository URLs are extracted from deps.dev for free.
+
+## Weaknesses
+
+- **`h1:` hashes are dirhashes, not file hashes.** The SHA-256 value
+  is a hash of a sorted file-content tree, not the raw zip bytes.
+  Tools that expect a plain file checksum may not be able to verify it.
+- **Proxy/API dependency.** If the Go proxy and deps.dev are both
+  unreachable, the transitive graph will be incomplete and dependency
+  nodes will lack license data.
+- **Zip fallback is heavier.** For modules not indexed by deps.dev,
+  the full module zip is downloaded to extract and classify the
+  LICENSE file. This is rare for public modules but adds bandwidth
+  for private or very new packages.

--- a/docs/decomposers/maven.md
+++ b/docs/decomposers/maven.md
@@ -1,0 +1,72 @@
+# Maven Decomposer
+
+**Location:** `source/maven/`
+
+## How it works
+
+1. Parses the local `pom.xml`.
+2. Resolves the effective POM by walking the parent chain, processing
+   BOM imports (`scope=import`, `type=pom`), and interpolating
+   `${property}` placeholders.
+3. Builds the dependency tree via BFS, applying Maven's
+   nearest-definition-wins mediation, scope transitivity rules,
+   exclude directives, and `dependencyManagement` overrides.
+4. Fetches artifact checksums (`.sha1`, `.sha256`) from the repository
+   in parallel. When `ModernHashes` is enabled, downloads the actual
+   artifacts and computes SHA-256/SHA-512 locally using the
+   `github.com/carabiner-dev/hasher` library.
+5. Resolves SNAPSHOT versions via the version-level
+   `maven-metadata.xml` to find timestamped artifact filenames.
+6. Converts the tree to a protobom NodeList using BFS edge ordering
+   to guarantee parents are added before children.
+
+## Data produced per dependency
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Name | POM | `artifactId` |
+| Version | POM / mediation | After range resolution and management |
+| PURL | computed | `pkg:maven/{groupId}/{artifactId}@{version}[?type=...&classifier=...&repository_url=...]` |
+| Download URL | computed | Full artifact URL using correct type/classifier |
+| Hashes | `.sha1`/`.sha256` files | Fetched in parallel; optionally SHA-256/SHA-512 computed locally |
+| License | dependency POM | Normalized to SPDX via `license.Normalize(name, url)` |
+| Scope | POM | Maps to edge types: `dependsOn`, `devDependency`, `optionalDependency` |
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `RepoURL` | `string` | `https://repo1.maven.org/maven2` | Maven repository URL |
+| `Concurrency` | `int` | `10` | Parallel HTTP requests |
+| `IncludeTest` | `bool` | `false` | Include test-scoped dependencies |
+| `IncludeProvided` | `bool` | `false` | Include provided-scoped dependencies |
+| `IncludeOptional` | `bool` | `false` | Include optional dependencies |
+| `ModernHashes` | `bool` | `false` | Download artifacts to compute SHA-256/SHA-512 |
+
+## Strengths
+
+- **Full POM resolution.** Handles parent chains, BOM imports, property
+  interpolation, replace directives, and version ranges.
+- **License extraction and normalization.** Reads `<licenses>` from every
+  dependency's POM and normalizes via the SPDX license list and
+  CycloneDX alias mapping.
+- **SNAPSHOT support.** Resolves timestamped snapshot versions from
+  `maven-metadata.xml` so that artifact URLs and hashes point to the
+  correct files.
+- **Complete PURLs.** Includes `type`, `classifier`, and `repository_url`
+  qualifiers when applicable.
+- **Parallel I/O.** All POM, hash, and artifact fetches use the
+  `khttp.Agent.GetGroup` parallel fetcher.
+
+## Weaknesses
+
+- **Network-heavy.** Resolving the full tree requires fetching the POM
+  for every transitive dependency. Large dependency trees produce
+  hundreds of HTTP requests.
+- **Single repository.** Only one Maven repository URL is supported.
+  Projects that pull from multiple repositories (Gradle-style) may
+  have missing dependencies.
+- **No Gradle/SBT support.** Only `pom.xml` is parsed. Gradle wrapper
+  or SBT build files are not understood.
+- **ModernHashes is expensive.** Downloading every JAR to compute
+  SHA-512 significantly increases runtime and bandwidth.

--- a/docs/decomposers/npm.md
+++ b/docs/decomposers/npm.md
@@ -1,0 +1,71 @@
+# npm Decomposer
+
+**Location:** `source/npm/`
+
+## How it works
+
+1. Parses `package.json` for root package metadata (name, version,
+   description, license, homepage, repository) and the list of
+   direct dependencies by type (normal, dev, peer, optional).
+2. Parses `package-lock.json` (lockfile v2/v3 format) which contains
+   the fully resolved dependency tree with exact versions, download
+   URLs, integrity hashes, and licenses for every package.
+3. Reconstructs the dependency graph from the flattened lock file
+   entries, mapping nested `node_modules` paths to parent-child
+   relationships.
+4. Converts the graph to a protobom NodeList.
+
+## Data produced per dependency
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Name | `package-lock.json` | Extracted from `node_modules/` path |
+| Version | `package-lock.json` | Exact resolved version |
+| PURL | computed | `pkg:npm/[@scope/]name@version` |
+| Download URL | `package-lock.json` | `resolved` field (registry tarball URL) |
+| Hash | `package-lock.json` | `integrity` field (SRI format: sha512/384/256/1) |
+| License | `package-lock.json` | Normalized to SPDX |
+
+### Root node additional data
+
+| Field | Source |
+|-------|--------|
+| Description | `package.json` |
+| Homepage | `package.json` (as `ExternalReference_WEBSITE`) |
+| Repository | `package.json` (as `ExternalReference_VCS`) |
+| License | `package.json` (normalized) |
+
+## Options
+
+The npm decomposer currently has no ecosystem-specific options beyond
+the common `DecomposerOptions`.
+
+## Strengths
+
+- **No network requests.** All data comes from local files.
+  `package-lock.json` already contains resolved URLs, integrity
+  hashes, and license identifiers for every dependency.
+- **Strong hashes.** npm uses SHA-512 by default for integrity
+  checks, providing high-quality cryptographic hashes out of the box.
+- **Fast.** No HTTP fetching means decomposition completes in
+  milliseconds even for large trees.
+- **Scoped package support.** Correctly handles `@scope/name`
+  packages in both PURL generation and dependency resolution.
+
+## Weaknesses
+
+- **Lockfile v1 not supported.** Only lockfile versions 2 and 3
+  (with the `packages` key) are supported. Projects using the older
+  `dependencies`-keyed format need to regenerate their lockfile with
+  a modern npm version.
+- **No remote enrichment.** Unlike Maven and Rust, the npm decomposer
+  does not fetch additional metadata from the registry. Description,
+  homepage, and repository are only available for the root package
+  (from `package.json`), not for dependencies.
+- **License field limitations.** `package-lock.json` only includes a
+  simple `license` string. Packages with complex license expressions
+  in their own `package.json` (e.g., `(MIT OR Apache-2.0)`) may be
+  simplified or missing in the lock file.
+- **Workspace support.** npm workspaces (monorepos) are not explicitly
+  handled. Each workspace package would need to be decomposed
+  separately.

--- a/docs/decomposers/rust.md
+++ b/docs/decomposers/rust.md
@@ -1,0 +1,84 @@
+# Rust Decomposer
+
+**Location:** `source/rust/`
+
+## How it works
+
+1. Parses `Cargo.toml` for root package metadata (name, version,
+   license, edition) and the list of direct dependencies by type
+   (normal, dev, build).
+2. Parses `Cargo.lock` for the fully resolved dependency tree with
+   exact versions, checksums, and source information.
+3. Reconstructs the dependency graph by recursively resolving
+   dependency references from the lock file, handling multiple
+   versions of the same crate.
+4. Enriches every dependency node by fetching metadata from the
+   crates.io API (`/api/v1/crates/{name}/{version}`) in parallel.
+5. Converts the graph to a protobom NodeList.
+
+## Data produced per dependency
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Name | `Cargo.lock` | Crate name |
+| Version | `Cargo.lock` | Exact resolved version |
+| PURL | computed | `pkg:cargo/{name}@{version}` |
+| Download URL | computed | `https://crates.io/api/v1/crates/{name}/{version}/download` |
+| Hash (SHA-256) | `Cargo.lock` | `checksum` field |
+| License | crates.io API | Normalized to SPDX |
+| Description | crates.io API | Short crate description |
+| Homepage | crates.io API | Set as `UrlHome` |
+| Repository | crates.io API | `ExternalReference_VCS` |
+| Documentation | crates.io API | `ExternalReference_DOCUMENTATION` |
+| Crate size | crates.io API | `Property` (`crates.io:crate_size`) |
+| Rust version (MSRV) | crates.io API | `Property` (`crates.io:rust_version`) |
+
+### Root node additional data
+
+| Field | Source |
+|-------|--------|
+| License | `Cargo.toml` (`package.license`, normalized) |
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `IncludeDevDependencies` | `bool` | `false` | Include dev dependencies |
+| `IncludeBuildDependencies` | `bool` | `false` | Include build dependencies |
+| `Concurrency` | `int` | `10` | Parallel crates.io API requests |
+
+## Strengths
+
+- **Rich metadata from crates.io.** Every dependency gets license,
+  description, homepage, repository, documentation URL, crate size,
+  and minimum Rust version -- all fetched in a single parallel batch.
+- **Checksums from lock file.** `Cargo.lock` includes SHA-256
+  checksums for every crate, verified by Cargo during builds.
+- **Multiple version handling.** Correctly resolves cases where
+  multiple versions of the same crate coexist in the dependency tree
+  (e.g., `hashbrown 0.14` and `hashbrown 0.15`).
+- **Dependency type classification.** Direct dependencies are
+  classified as normal, dev, or build based on `Cargo.toml` sections,
+  mapping to appropriate protobom edge types.
+- **License normalization.** Both root (from `Cargo.toml`) and
+  dependency licenses (from crates.io) are normalized to SPDX
+  identifiers.
+
+## Weaknesses
+
+- **crates.io dependency.** Enrichment requires network access to the
+  crates.io API. If the API is unreachable, dependency nodes will
+  have checksums but no license, description, or other metadata.
+- **No private registry support.** Only the public crates.io registry
+  is supported. Crates from private registries or git sources will
+  not be enriched.
+- **Platform-specific dependencies.** `Cargo.lock` includes
+  dependencies for all platforms. The decomposer includes all of
+  them, which may be a superset of what builds on any single
+  platform. This matches `cargo tree --all-targets` behavior.
+- **No feature flag tracking.** Cargo's feature system affects which
+  optional dependencies are included, but the decomposer does not
+  track which features are active.
+- **API rate limiting.** Large dependency trees generate many
+  crates.io requests. While they run in parallel with configurable
+  concurrency, very large projects may hit API rate limits.


### PR DESCRIPTION
This pull request significantly expands and clarifies the documentation for Unpack's decomposers, detailing support for four major package ecosystems: Go, Maven, npm, and Rust. The main README now summarizes supported ecosystems in a table, while new and updated documentation files provide in-depth explanations of how each decomposer works, their strengths, weaknesses, and the data they produce. This makes it much easier for users and contributors to understand Unpack's capabilities and architecture.

**Documentation improvements and ecosystem support:**

* The `README.md` now lists supported ecosystems in a table, replacing the old bullet list, and links to detailed decomposer documentation. It also clarifies licensing and contribution guidelines. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R120) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L129-R135)
* A new `docs/decomposers/README.md` document provides an overview of decomposer architecture, shared features, and links to per-ecosystem documentation.

**Detailed per-ecosystem documentation:**

* Added `docs/decomposers/golang.md` describing the Go decomposer’s parsing, enrichment via deps.dev, data produced, options, strengths, and weaknesses.
* Added `docs/decomposers/maven.md` detailing the Maven decomposer’s POM resolution, dependency mediation, hash fetching, options, and limitations.
* Added `docs/decomposers/npm.md` covering the npm decomposer’s lockfile parsing, dependency graph reconstruction, and its strengths/weaknesses.
* Added `docs/decomposers/rust.md` describing the Rust decomposer’s use of Cargo files, crates.io enrichment, and handling of dependency types and metadata.