### PR TITLE
Implement networking levels in CLI and decomposers

### DIFF
--- a/api/v1/options.go
+++ b/api/v1/options.go
@@ -5,6 +5,25 @@ package v1
 
 import "fmt"
 
+// NetworkLevel controls how much network access the decomposers are allowed to use.
+type NetworkLevel int
+
+const (
+	// NetworkEssential is the default (zero value). Enables network calls
+	// that are essential for building the dependency tree plus lightweight
+	// metadata requests (e.g., deps.dev, checksum files, crates.io API).
+	NetworkEssential NetworkLevel = iota
+
+	// NetworkFull enables all network calls including downloading full
+	// artifacts for hash computation and zip archives for license
+	// classification. Prioritizes data completeness over bandwidth.
+	NetworkFull
+
+	// NetworkDisabled disables all network calls. Only local data is used.
+	// Some decomposers may produce incomplete results or fail entirely.
+	NetworkDisabled NetworkLevel = -1
+)
+
 // DecomposerOptions is the options set that goes into an Extract() run in
 // a decomposer. They are meant to be ephimeral, for the invocation only, and
 // derived from the Unpacker configuration whe invoked from there.
@@ -16,6 +35,10 @@ type DecomposerOptions struct {
 
 	// CommitHash captures the hash of the last commit when running in a repository
 	CommitHash string
+
+	// Networking controls how much network access decomposers are allowed.
+	// Defaults to NetworkEssential.
+	Networking NetworkLevel
 
 	driverOptions map[string]any
 }

--- a/dependencies/implementation.go
+++ b/dependencies/implementation.go
@@ -108,6 +108,7 @@ func (di *defaultImplementation) ExtractCodeBases(
 				WorkDir:    cbPath,
 				Version:    ver,
 				CommitHash: hashHex,
+				Networking: opts.Networking,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("from %q with %T: %w", cbPath, d, err)

--- a/dependencies/unpacker.go
+++ b/dependencies/unpacker.go
@@ -68,6 +68,10 @@ type Options struct {
 	// If empty, all codebases are included.
 	CodebaseFilter string
 
+	// Networking controls how much network access decomposers are allowed.
+	// Defaults to NetworkEssential.
+	Networking api.NetworkLevel
+
 	logger *slog.Logger
 }
 

--- a/docs/decomposers/README.md
+++ b/docs/decomposers/README.md
@@ -26,6 +26,33 @@ All decomposers share these behaviors:
 - **Version override** -- when `DecomposerOptions.Version` is set, the root
   node's version and PURL are updated accordingly.
 
+## Networking tiers
+
+The `DecomposerOptions.Networking` field controls how much network access
+decomposers are allowed. This is a top-level option that affects all
+decomposers uniformly.
+
+| Level | Value | Description |
+|-------|-------|-------------|
+| `NetworkEssential` | `0` (default) | Enables network calls essential for building the dependency tree plus lightweight metadata requests (deps.dev, checksum files, crates.io API). |
+| `NetworkFull` | `1` | All of essential, plus downloading full artifacts for hash computation and zip archives for license classification. Prioritizes completeness over bandwidth. |
+| `NetworkDisabled` | `-1` | No network calls. Only local data is used. Some decomposers will produce incomplete results (Go, Maven) while others work fully offline (npm, Rust without enrichment). |
+
+### Per-decomposer networking behavior
+
+| Call | disabled | essential | full |
+|------|----------|-----------|------|
+| **Go:** proxy .mod fetch (dependency graph) | skip | yes | yes |
+| **Go:** deps.dev API (licenses, VCS) | skip | yes | yes |
+| **Go:** proxy .zip download (license fallback) | skip | skip | yes |
+| **Maven:** POM fetch (dependency tree) | skip | yes | yes |
+| **Maven:** metadata fetch (snapshots, ranges) | skip | yes | yes |
+| **Maven:** checksum files (.sha1, .sha256) | skip | yes | yes |
+| **Maven:** artifact download (SHA-256/SHA-512) | skip | skip | yes |
+| **npm:** _(none -- fully offline)_ | works | works | works |
+| **Rust:** local parsing (Cargo.toml/lock) | works | works | works |
+| **Rust:** crates.io API (enrichment) | skip | yes | yes |
+
 ## Per-decomposer docs
 
 See the individual pages linked in the table above for implementation

--- a/docs/decomposers/golang.md
+++ b/docs/decomposers/golang.md
@@ -14,10 +14,10 @@
    configurable concurrency.
 4. Converts the graph into a protobom NodeList.
 5. Enriches dependency nodes with license and source repository data
-   from the [deps.dev API](https://docs.deps.dev/api/v3/). For any
-   modules not found in deps.dev, falls back to downloading the
-   module zip from the proxy, extracting the LICENSE file, and
-   classifying it with `google/licenseclassifier/v2`.
+   from the [deps.dev API](https://docs.deps.dev/api/v3/). With
+   `NetworkFull`, also falls back to downloading module zips from the
+   proxy for any modules not found in deps.dev, extracting the LICENSE
+   file, and classifying it with `google/licenseclassifier/v2`.
 
 ## Data produced per dependency
 
@@ -65,7 +65,7 @@
 - **Proxy/API dependency.** If the Go proxy and deps.dev are both
   unreachable, the transitive graph will be incomplete and dependency
   nodes will lack license data.
-- **Zip fallback is heavier.** For modules not indexed by deps.dev,
-  the full module zip is downloaded to extract and classify the
-  LICENSE file. This is rare for public modules but adds bandwidth
-  for private or very new packages.
+- **Zip fallback is heavier.** With `NetworkFull`, for modules not
+  indexed by deps.dev, the full module zip is downloaded to extract
+  and classify the LICENSE file. This is rare for public modules but
+  adds bandwidth for private or very new packages.

--- a/docs/decomposers/maven.md
+++ b/docs/decomposers/maven.md
@@ -12,7 +12,7 @@
    nearest-definition-wins mediation, scope transitivity rules,
    exclude directives, and `dependencyManagement` overrides.
 4. Fetches artifact checksums (`.sha1`, `.sha256`) from the repository
-   in parallel. When `ModernHashes` is enabled, downloads the actual
+   in parallel. With `NetworkFull`, also downloads the actual
    artifacts and computes SHA-256/SHA-512 locally using the
    `github.com/carabiner-dev/hasher` library.
 5. Resolves SNAPSHOT versions via the version-level
@@ -41,7 +41,9 @@
 | `IncludeTest` | `bool` | `false` | Include test-scoped dependencies |
 | `IncludeProvided` | `bool` | `false` | Include provided-scoped dependencies |
 | `IncludeOptional` | `bool` | `false` | Include optional dependencies |
-| `ModernHashes` | `bool` | `false` | Download artifacts to compute SHA-256/SHA-512 |
+
+Artifact download for SHA-256/SHA-512 computation is controlled by the
+top-level `Networking` setting (`NetworkFull`).
 
 ## Strengths
 
@@ -68,5 +70,6 @@
   have missing dependencies.
 - **No Gradle/SBT support.** Only `pom.xml` is parsed. Gradle wrapper
   or SBT build files are not understood.
-- **ModernHashes is expensive.** Downloading every JAR to compute
-  SHA-512 significantly increases runtime and bandwidth.
+- **Full hashing is expensive.** With `NetworkFull`, downloading
+  every JAR to compute SHA-512 significantly increases runtime and
+  bandwidth.

--- a/internal/cmd/extract.go
+++ b/internal/cmd/extract.go
@@ -19,6 +19,7 @@ import (
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/spf13/cobra"
 
+	api "github.com/carabiner-dev/unpack/api/v1"
 	"github.com/carabiner-dev/unpack/dependencies"
 )
 
@@ -33,6 +34,7 @@ type extractOptions struct {
 	IgnorePatterns       []string
 	Path                 string
 	Format               string
+	Networking           string
 	IndexFiles           bool
 	Attest               bool
 	Sign                 bool
@@ -54,6 +56,10 @@ func (ro *extractOptions) Validate() error {
 
 	if !slices.Contains(validFormats, ro.Format) {
 		errs = append(errs, errors.New("invalid format"))
+	}
+
+	if !slices.Contains([]string{"essential", "full", "disabled"}, ro.Networking) {
+		errs = append(errs, fmt.Errorf("invalid networking level %q (must be essential, full, or disabled)", ro.Networking))
 	}
 
 	// --sign implies --attest
@@ -85,6 +91,11 @@ func (ro *extractOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringVarP(
 		&ro.Format, "format", "f", formatTree, fmt.Sprintf("format for the output %+v", validFormats),
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&ro.Networking, "networking", "essential",
+		"network access level: essential (default), full, or disabled",
 	)
 
 	cmd.PersistentFlags().BoolVar(
@@ -196,6 +207,16 @@ to the current directory.
 
 			// Filter to a specific codebase if provided
 			unpacker.Options.CodebaseFilter = opts.Codebase
+
+			// Set networking level
+			switch opts.Networking {
+			case "full":
+				unpacker.Options.Networking = api.NetworkFull
+			case "disabled":
+				unpacker.Options.Networking = api.NetworkDisabled
+			default:
+				unpacker.Options.Networking = api.NetworkEssential
+			}
 
 			// Ensure the output directory exists when writing to files
 			if opts.OutputPath != "" {

--- a/source/golang/decomposer.go
+++ b/source/golang/decomposer.go
@@ -77,8 +77,8 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 		return nil, fmt.Errorf("parsing go.mod: %w", err)
 	}
 
-	// 2. Build dependency tree by fetching go.mod files from the proxy
-	trees, sumHashes, err := d.buildDependencyTree(modFile, goModPath, dOpts)
+	// 2. Build dependency tree (fetches go.mod files from proxy when networking allows)
+	trees, sumHashes, err := d.buildDependencyTree(modFile, goModPath, dOpts, opts.Networking)
 	if err != nil {
 		return nil, fmt.Errorf("building dependency tree: %w", err)
 	}
@@ -94,8 +94,10 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 		return nil, fmt.Errorf("converting graph trees: %w", err)
 	}
 
-	// 4. Fetch licenses from module zips
-	d.enrichLicenses(nl, root, dOpts)
+	// 4. Enrich with license and VCS data (requires networking >= essential)
+	if opts.Networking >= api.NetworkEssential {
+		d.enrichLicenses(nl, root, dOpts, opts.Networking)
+	}
 
 	return nl, nil
 }
@@ -104,7 +106,7 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 // falling back to downloading module zips from the Go proxy for
 // modules not found in deps.dev. Sets licenses and VCS external
 // references on dependency nodes.
-func (d *Decomposer) enrichLicenses(nl *sbom.NodeList, rootModule string, opts *Options) {
+func (d *Decomposer) enrichLicenses(nl *sbom.NodeList, rootModule string, opts *Options, networking api.NetworkLevel) {
 	// Collect dependency modules that need enrichment
 	var modules []modKey
 	for _, node := range nl.GetNodes() {
@@ -128,7 +130,7 @@ func (d *Decomposer) enrichLicenses(nl *sbom.NodeList, rootModule string, opts *
 	}
 
 	lc := newLicenseClient(opts.ProxyURL, opts.Concurrency)
-	results := lc.FetchLicenses(modules)
+	results := lc.FetchLicenses(modules, networking >= api.NetworkFull)
 
 	// Apply enrichment data to nodes
 	for _, node := range nl.GetNodes() {
@@ -236,7 +238,7 @@ type replaceTarget struct {
 // 3. Building edges only between modules in the resolved set\
 //
 //nolint:gocritic,unparam
-func (d *Decomposer) buildDependencyTree(root *modfile.File, goModPath string, opts *Options) (*map[string][]string, map[string][]string, error) {
+func (d *Decomposer) buildDependencyTree(root *modfile.File, goModPath string, opts *Options, networking api.NetworkLevel) (*map[string][]string, map[string][]string, error) {
 	trees := make(map[string][]string)
 
 	// Build replace directive map
@@ -292,7 +294,10 @@ func (d *Decomposer) buildDependencyTree(root *modfile.File, goModPath string, o
 	}
 
 	// Fetch go.mod files for all modules in the resolved set to get their dependencies
-	d.fetchDependencyGraph(trees, resolvedSet, replaces, opts)
+	// (requires networking >= essential)
+	if networking >= api.NetworkEssential {
+		d.fetchDependencyGraph(trees, resolvedSet, replaces, opts)
+	}
 
 	return &trees, allSumHashes, nil
 }

--- a/source/golang/decomposer_test.go
+++ b/source/golang/decomposer_test.go
@@ -96,7 +96,7 @@ func TestBuildDependencyTree(t *testing.T) {
 	modFile, err := d.parseLocalGoMod("testdata/simple/go.mod")
 	require.NoError(t, err)
 
-	trees, _, err := d.buildDependencyTree(modFile, "testdata/simple/go.mod", &defaultOptions)
+	trees, _, err := d.buildDependencyTree(modFile, "testdata/simple/go.mod", &defaultOptions, api.NetworkEssential)
 	require.NoError(t, err)
 	require.NotNil(t, trees)
 
@@ -114,7 +114,7 @@ func TestBuildDependencyTreeWithReplace(t *testing.T) {
 	modFile, err := d.parseLocalGoMod("testdata/with-replace/go.mod")
 	require.NoError(t, err)
 
-	trees, _, err := d.buildDependencyTree(modFile, "testdata/with-replace/go.mod", &defaultOptions)
+	trees, _, err := d.buildDependencyTree(modFile, "testdata/with-replace/go.mod", &defaultOptions, api.NetworkEssential)
 	require.NoError(t, err)
 	require.NotNil(t, trees)
 

--- a/source/golang/license.go
+++ b/source/golang/license.go
@@ -110,9 +110,10 @@ type licenseResult struct {
 }
 
 // FetchLicenses fetches license information for all modules. It first
-// queries deps.dev in parallel, then falls back to downloading module
-// zips from the Go proxy for any modules not found in deps.dev.
-func (lc *licenseClient) FetchLicenses(modules []modKey) map[string]*licenseResult {
+// queries deps.dev in parallel. When zipFallback is true, it also
+// downloads module zips from the Go proxy for any modules not found
+// in deps.dev and classifies their LICENSE files locally.
+func (lc *licenseClient) FetchLicenses(modules []modKey, zipFallback bool) map[string]*licenseResult {
 	if len(modules) == 0 {
 		return nil
 	}
@@ -129,8 +130,8 @@ func (lc *licenseClient) FetchLicenses(modules []modKey) map[string]*licenseResu
 		}
 	}
 
-	// Phase 3: fall back to zip download for missing modules
-	if len(missing) > 0 {
+	// Phase 3: fall back to zip download for missing modules (NetworkFull only)
+	if zipFallback && len(missing) > 0 {
 		zipResults := lc.fetchFromZips(missing)
 		for k, v := range zipResults {
 			result[k] = v

--- a/source/maven/decomposer.go
+++ b/source/maven/decomposer.go
@@ -30,7 +30,6 @@ type Options struct {
 	IncludeTest     bool   // Include test-scoped dependencies (default: false)
 	IncludeProvided bool   // Include provided-scoped dependencies (default: false)
 	IncludeOptional bool   // Include optional dependencies (default: false)
-	ModernHashes    bool   // Download artifacts and compute SHA-256 and SHA-512 hashes
 }
 
 var defaultOptions = Options{
@@ -60,23 +59,34 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 		return nil, fmt.Errorf("parsing pom.xml: %w", err)
 	}
 
-	// 2. Create resolver for fetching remote POMs
-	resolver := NewResolver(dOpts)
+	// 2. Create resolver for fetching remote POMs (requires networking)
+	var resolver *Resolver
+	if opts.Networking >= api.NetworkEssential {
+		resolver = NewResolver(dOpts)
+	}
 
 	// 3. Resolve effective POM (parent chain + BOM imports + interpolation)
-	effective, err := resolver.ResolveEffectivePOM(pom)
-	if err != nil {
-		return nil, fmt.Errorf("resolving effective POM: %w", err)
+	effective := pom
+	if resolver != nil {
+		resolved, err := resolver.ResolveEffectivePOM(pom)
+		if err != nil {
+			return nil, fmt.Errorf("resolving effective POM: %w", err)
+		}
+		effective = resolved
 	}
 
 	// 4. Build dependency tree
 	dt := NewDependencyTree(effective, resolver, dOpts)
-	if err := dt.Build(); err != nil {
-		return nil, fmt.Errorf("building dependency tree: %w", err)
+	if resolver != nil {
+		if err := dt.Build(); err != nil {
+			return nil, fmt.Errorf("building dependency tree: %w", err)
+		}
 	}
 
-	// 5. Fetch artifact hashes in parallel
-	dt.FetchHashes()
+	// 5. Fetch artifact hashes (essential: checksum files; full: download+compute)
+	if opts.Networking >= api.NetworkEssential {
+		dt.FetchHashes(opts.Networking >= api.NetworkFull)
+	}
 
 	// 6. Convert to NodeList
 	nl, err := dt.ToNodeList(opts)

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -322,7 +322,9 @@ func scopeTransitivity(parentScope, depScope string) string {
 
 // FetchHashes fetches artifact checksums for all resolved dependencies
 // in parallel and stores them in the resolved dependency entries.
-func (dt *DependencyTree) FetchHashes() {
+// When computeModern is true, it also downloads artifacts to compute
+// SHA-256 and SHA-512 hashes locally.
+func (dt *DependencyTree) FetchHashes(computeModern bool) {
 	if dt.resolver == nil {
 		return
 	}
@@ -354,8 +356,8 @@ func (dt *DependencyTree) FetchHashes() {
 	// Fetch all checksum file hashes in parallel
 	allHashes := dt.resolver.FetchAllArtifactHashes(coords)
 
-	// If ModernHashes is enabled, download artifacts and compute SHA-256/SHA-512
-	if dt.opts.ModernHashes {
+	// If computeModern is enabled, download artifacts and compute SHA-256/SHA-512
+	if computeModern {
 		computed := dt.resolver.ComputeArtifactHashes(coords)
 		for key, hashes := range computed {
 			if existing, ok := allHashes[key]; ok {

--- a/source/rust/decomposer.go
+++ b/source/rust/decomposer.go
@@ -79,8 +79,11 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 	}
 
 	// Enrich dependency nodes with metadata from crates.io
-	client := NewCratesIOClient(dOpts.Concurrency)
-	tree.Enrich(client)
+	// (requires networking >= essential)
+	if opts.Networking >= api.NetworkEssential {
+		client := NewCratesIOClient(dOpts.Concurrency)
+		tree.Enrich(client)
+	}
 
 	return nl, nil
 }


### PR DESCRIPTION
This pull request introduces a configurable networking tier system for decomposers, allowing fine-grained control over network access when extracting dependency information. It adds a `Networking` option that can be set to `essential`, `full`, or `disabled`, affecting how much remote data is fetched for dependency resolution and enrichment. The change is applied consistently across the Go and Maven decomposers, updates the CLI, and thoroughly documents the new behavior.

**Key changes:**

**Networking tier system implementation:**
- Introduced the `NetworkLevel` type and constants (`NetworkEssential`, `NetworkFull`, `NetworkDisabled`) in `api/v1/options.go` to control decomposer network access. This is now part of `DecomposerOptions` and `Unpacker.Options`. [[1]](diffhunk://#diff-bfd7abdae613b588cce273c5346fc46f8ce4af63acf91a08bd84ba006dc02bebR8-R26) [[2]](diffhunk://#diff-bfd7abdae613b588cce273c5346fc46f8ce4af63acf91a08bd84ba006dc02bebR39-R42) [[3]](diffhunk://#diff-2644a7b5d25dac758266bc466de16c3594c2355f4a7fd64f8ffece271c533619R71-R74)
- Updated the CLI (`extract` command) to accept a `--networking` flag, validated its value, and mapped it to the new `NetworkLevel` setting in the options. [[1]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR37) [[2]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR61-R64) [[3]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR96-R100) [[4]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR211-R220)

**Go decomposer enhancements:**
- Refactored the Go decomposer to respect the networking tier, limiting or enabling network calls for dependency resolution and license enrichment based on the selected level. The fallback to downloading module zips for license classification is now only enabled with `NetworkFull`. [[1]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL80-R81) [[2]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL97-R100) [[3]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL107-R109) [[4]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL131-R133) [[5]](diffhunk://#diff-a9fc22022b528c89ea961d5f0050497f580c6af0af4997a7ba0329c8e183e18fL239-R241) [[6]](diffhunk://#diff-0078e2cc09a1562d5ba1d8bc5ff2d46cb1c56ffe5d2cbf5bb233a5d0ba6ace8cL113-R116) [[7]](diffhunk://#diff-0078e2cc09a1562d5ba1d8bc5ff2d46cb1c56ffe5d2cbf5bb233a5d0ba6ace8cL132-R134)
- Updated Go decomposer tests to use the new `NetworkLevel` parameter. [[1]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336L99-R99) [[2]](diffhunk://#diff-aeef58232285f350740479f5a9fef5427b23185ec7b2cb86e791f75969fa8336L117-R117)

**Maven decomposer enhancements:**
- Refactored the Maven decomposer to use the networking tier for remote POM and artifact fetching. Artifact download for hash computation is now controlled by the networking tier, not the `ModernHashes` flag. [[1]](diffhunk://#diff-f144342b8becfe7cfd4a8969df61a4662ec156b13aa32d7bc6f7bf84028b71b9L33) [[2]](diffhunk://#diff-f144342b8becfe7cfd4a8969df61a4662ec156b13aa32d7bc6f7bf84028b71b9L63-R89) [[3]](diffhunk://#diff-19afce67592d18d298b58c324cae24a4ac6912ddfbcb54f28e5da963dda48e59L325-R327)

**Documentation updates:**
- Added a new section to `docs/decomposers/README.md` describing the networking tiers and their effects on each decomposer, including a detailed table of behaviors.
- Updated Go and Maven decomposer docs to clarify how network tier selection affects dependency resolution, license enrichment, and artifact hash computation. [[1]](diffhunk://#diff-38fc05dd72137ba8a6ede9ea384648e9b0ae4c89a8310bab26570492bdc9d3c7L17-R20) [[2]](diffhunk://#diff-38fc05dd72137ba8a6ede9ea384648e9b0ae4c89a8310bab26570492bdc9d3c7L68-R71) [[3]](diffhunk://#diff-c77a3b13a3e9872a60e4d20031e2d33181fefaf6d05774b6c1491ac676812c2dL15-R15) [[4]](diffhunk://#diff-c77a3b13a3e9872a60e4d20031e2d33181fefaf6d05774b6c1491ac676812c2dL44-R46) [[5]](diffhunk://#diff-c77a3b13a3e9872a60e4d20031e2d33181fefaf6d05774b6c1491ac676812c2dL71-R75)

**Internal and dependency wiring:**
- Propagated the new networking option through all relevant code paths, including the main implementation, options structs, and CLI entrypoints. [[1]](diffhunk://#diff-b5fafd10aa744023f8d2d5db5e3970a32c592c36e3d8c0601c8c68bd60317ae9R111) [[2]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR22)

These changes provide users with explicit control over bandwidth usage and data completeness during dependency extraction, and ensure consistent, well-documented behavior across decomposers.