### PR TITLE
Record repository URLs from pom when custom

### DIFF
--- a/source/maven/pom.go
+++ b/source/maven/pom.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/text/encoding/ianaindex"
 )
@@ -143,9 +144,34 @@ type DependencyManagement struct {
 
 // Repository represents a Maven repository declaration.
 type Repository struct {
-	ID   string `xml:"id"`
-	URL  string `xml:"url"`
-	Name string `xml:"name"`
+	ID        string            `xml:"id"`
+	URL       string            `xml:"url"`
+	Name      string            `xml:"name"`
+	Snapshots *RepositoryPolicy `xml:"snapshots"`
+	Releases  *RepositoryPolicy `xml:"releases"`
+}
+
+// SnapshotsEnabled returns true if this repository serves snapshot artifacts.
+// Maven defaults to false for snapshots.
+func (r Repository) SnapshotsEnabled() bool {
+	if r.Snapshots == nil {
+		return false
+	}
+	return strings.EqualFold(r.Snapshots.Enabled, "true")
+}
+
+// ReleasesEnabled returns true if this repository serves release artifacts.
+// Maven defaults to true for releases.
+func (r Repository) ReleasesEnabled() bool {
+	if r.Releases == nil {
+		return true
+	}
+	return !strings.EqualFold(r.Releases.Enabled, "false")
+}
+
+// RepositoryPolicy controls whether a repository serves releases or snapshots.
+type RepositoryPolicy struct {
+	Enabled string `xml:"enabled"`
 }
 
 // Properties is a map of Maven property key-value pairs.

--- a/source/maven/pom_test.go
+++ b/source/maven/pom_test.go
@@ -164,3 +164,43 @@ func TestEffectiveGroupIDAndVersion(t *testing.T) {
 	require.Equal(t, "own.group", pom.EffectiveGroupID())
 	require.Equal(t, "1.0", pom.EffectiveVersion())
 }
+
+func TestRepositorySnapshotsEnabled(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		repo Repository
+		want bool
+	}{
+		{"nil policy defaults to false", Repository{}, false},
+		{"enabled true", Repository{Snapshots: &RepositoryPolicy{Enabled: "true"}}, true},
+		{"enabled TRUE", Repository{Snapshots: &RepositoryPolicy{Enabled: "TRUE"}}, true},
+		{"enabled false", Repository{Snapshots: &RepositoryPolicy{Enabled: "false"}}, false},
+		{"enabled empty", Repository{Snapshots: &RepositoryPolicy{Enabled: ""}}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.repo.SnapshotsEnabled())
+		})
+	}
+}
+
+func TestRepositoryReleasesEnabled(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		repo Repository
+		want bool
+	}{
+		{"nil policy defaults to true", Repository{}, true},
+		{"enabled true", Repository{Releases: &RepositoryPolicy{Enabled: "true"}}, true},
+		{"enabled false", Repository{Releases: &RepositoryPolicy{Enabled: "false"}}, false},
+		{"enabled FALSE", Repository{Releases: &RepositoryPolicy{Enabled: "FALSE"}}, false},
+		{"enabled empty", Repository{Releases: &RepositoryPolicy{Enabled: ""}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.repo.ReleasesEnabled())
+		})
+	}
+}

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -169,7 +169,7 @@ func (dt *DependencyTree) Build() error {
 			Version:    version,
 			Type:       dep.EffectiveType(),
 			Classifier: dep.Classifier,
-			RepoURL:    dt.nonDefaultRepoURL(),
+			RepoURL:    dt.repoURLForDep(version),
 		}
 
 		// Fetch the dependency's POM for license info and transitive deps
@@ -485,8 +485,12 @@ func (dt *DependencyTree) ToNodeList(opts *api.DecomposerOptions) (*sbom.NodeLis
 // createDependencyNode creates a protobom Node for a resolved dependency.
 func (dt *DependencyTree) createDependencyNode(rd *ResolvedDependency) *sbom.Node {
 	groupPath := strings.ReplaceAll(rd.Coordinate.GroupID, ".", "/")
+	repoURL := rd.Coordinate.RepoURL
+	if repoURL == "" {
+		repoURL = defaultRepoURL
+	}
 	downloadURL := fmt.Sprintf("%s/%s/%s/%s/%s",
-		defaultRepoURL, groupPath,
+		repoURL, groupPath,
 		rd.Coordinate.ArtifactID, rd.Coordinate.Version,
 		rd.Coordinate.ArtifactFilename(),
 	)
@@ -519,6 +523,30 @@ func (dt *DependencyTree) nonDefaultRepoURL() string {
 	if dt.resolver != nil && dt.resolver.RepoURL != defaultRepoURL {
 		return dt.resolver.RepoURL
 	}
+	return ""
+}
+
+// repoURLForDep returns the repository URL qualifier for a dependency.
+// For SNAPSHOT versions it checks the POM's declared repositories for one
+// with snapshots enabled. Falls back to the global resolver URL override.
+func (dt *DependencyTree) repoURLForDep(version string) string {
+	// Global resolver override takes precedence
+	if url := dt.nonDefaultRepoURL(); url != "" {
+		return url
+	}
+
+	// For SNAPSHOT versions, look for a POM-declared repository with snapshots enabled
+	if isSnapshot(version) && dt.rootPOM != nil {
+		for _, repo := range dt.rootPOM.Repositories {
+			if repo.SnapshotsEnabled() {
+				url := strings.TrimRight(repo.URL, "/")
+				if url != "" && url != defaultRepoURL {
+					return url
+				}
+			}
+		}
+	}
+
 	return ""
 }
 

--- a/source/maven/tree_test.go
+++ b/source/maven/tree_test.go
@@ -268,3 +268,126 @@ func TestToNodeListEdgeTypes(t *testing.T) {
 	// Should have 3 nodes: root + 2 deps
 	require.Len(t, nl.GetNodes(), 3)
 }
+
+func TestRepoURLForDep(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		repos   []Repository
+		version string
+		want    string
+	}{
+		{
+			"release version no repos",
+			nil,
+			"1.0.0",
+			"",
+		},
+		{
+			"snapshot version no repos",
+			nil,
+			"1.0-SNAPSHOT",
+			"",
+		},
+		{
+			"snapshot version with snapshot repo",
+			[]Repository{{
+				ID:        "snapshots",
+				URL:       "https://repo.example.com/snapshots",
+				Snapshots: &RepositoryPolicy{Enabled: "true"},
+			}},
+			"1.0-SNAPSHOT",
+			"https://repo.example.com/snapshots",
+		},
+		{
+			"snapshot version with trailing slash",
+			[]Repository{{
+				ID:        "snapshots",
+				URL:       "https://repo.example.com/snapshots/",
+				Snapshots: &RepositoryPolicy{Enabled: "true"},
+			}},
+			"1.0-SNAPSHOT",
+			"https://repo.example.com/snapshots",
+		},
+		{
+			"release version with snapshot repo",
+			[]Repository{{
+				ID:        "snapshots",
+				URL:       "https://repo.example.com/snapshots",
+				Snapshots: &RepositoryPolicy{Enabled: "true"},
+				Releases:  &RepositoryPolicy{Enabled: "false"},
+			}},
+			"1.0.0",
+			"",
+		},
+		{
+			"snapshot version with snapshots disabled",
+			[]Repository{{
+				ID:        "releases-only",
+				URL:       "https://repo.example.com/releases",
+				Snapshots: &RepositoryPolicy{Enabled: "false"},
+			}},
+			"1.0-SNAPSHOT",
+			"",
+		},
+		{
+			"snapshot version with maven central repo",
+			[]Repository{{
+				ID:        "central",
+				URL:       "https://repo1.maven.org/maven2",
+				Snapshots: &RepositoryPolicy{Enabled: "true"},
+			}},
+			"1.0-SNAPSHOT",
+			"",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pom := &POM{
+				GroupID:      "com.example",
+				ArtifactID:   "app",
+				Version:      "1.0.0",
+				Repositories: tc.repos,
+			}
+			dt := NewDependencyTree(pom, nil, &defaultOptions)
+			got := dt.repoURLForDep(tc.version)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBuildTreeSnapshotRepoURL(t *testing.T) {
+	t.Parallel()
+	pom := &POM{
+		GroupID:    "com.example",
+		ArtifactID: "app",
+		Version:    "1.0.0",
+		Repositories: []Repository{{
+			ID:        "apache-snapshots",
+			Name:      "Apache Snapshots",
+			URL:       "https://repository.apache.org/content/repositories/snapshots/",
+			Snapshots: &RepositoryPolicy{Enabled: "true"},
+			Releases:  &RepositoryPolicy{Enabled: "false"},
+		}},
+		Dependencies: []Dependency{
+			{GroupID: "org.apache.commons", ArtifactID: "commons-lang3", Version: "3.21.0-SNAPSHOT"},
+			{GroupID: "org.apache.commons", ArtifactID: "commons-text", Version: "1.13.0"},
+		},
+	}
+
+	dt := NewDependencyTree(pom, nil, &defaultOptions)
+	err := dt.Build()
+	require.NoError(t, err)
+
+	// SNAPSHOT dep should have the repo URL
+	snapshotDep := dt.resolved["org.apache.commons:commons-lang3"]
+	require.NotNil(t, snapshotDep)
+	require.Equal(t, "https://repository.apache.org/content/repositories/snapshots", snapshotDep.Coordinate.RepoURL)
+	require.Contains(t, snapshotDep.Coordinate.PURL(), "repository_url=https://repository.apache.org/content/repositories/snapshots")
+
+	// Release dep should NOT have a repo URL
+	releaseDep := dt.resolved["org.apache.commons:commons-text"]
+	require.NotNil(t, releaseDep)
+	require.Empty(t, releaseDep.Coordinate.RepoURL)
+	require.NotContains(t, releaseDep.Coordinate.PURL(), "repository_url")
+}


### PR DESCRIPTION
This pull request enhances Maven repository handling, especially for snapshot dependencies, by introducing repository policy awareness and improving how repository URLs are assigned and propagated. It also adds comprehensive tests to ensure correct behavior for both snapshot and release artifacts.

**Repository policy support and snapshot handling:**

* Added `Snapshots` and `Releases` fields to the `Repository` struct in `pom.go`, along with methods `SnapshotsEnabled()` and `ReleasesEnabled()` to determine if a repository serves snapshot or release artifacts, following Maven's default behaviors. Also introduced the `RepositoryPolicy` struct.
* Implemented the `repoURLForDep` method in `tree.go`, which determines the appropriate repository URL for a dependency, prioritizing POM-declared repositories with snapshots enabled for snapshot versions, and falling back to global overrides.
* Updated dependency resolution in `Build()` to use `repoURLForDep`, ensuring snapshot dependencies can be associated with the correct repository URL.
* Modified node creation in `ToNodeList` to use the resolved dependency's repository URL, defaulting to the global repository if none is specified.

**Testing improvements:**

* Added thorough unit tests in `pom_test.go` and `tree_test.go` to verify repository policy logic (`SnapshotsEnabled`, `ReleasesEnabled`) and to ensure correct repository URL assignment for both snapshot and release dependencies, including integration tests for the full dependency tree build process. [[1]](diffhunk://#diff-efc9bb161a24d6ec72886fb46fa4c9fb0f9ca4af3d4c3ef7e89839917da4125aR167-R206) [[2]](diffhunk://#diff-d1f82261632700b9958d712c7ab392c39500d1052992c4563f3b1f7bafc6eca0R271-R393)

**Dependency update:**

* Imported the `strings` package in `pom.go` to support case-insensitive string comparisons for repository policy evaluation.