### PR TITLE
Support for other dep types

### DIFF
--- a/api/v1/options.go
+++ b/api/v1/options.go
@@ -40,6 +40,18 @@ type DecomposerOptions struct {
 	// Defaults to NetworkEssential.
 	Networking NetworkLevel
 
+	// IncludeDev includes development/test dependencies in the output.
+	// Maps to: Maven test scope, npm devDependencies, Rust dev-dependencies.
+	IncludeDev bool
+
+	// IncludeBuild includes build tool dependencies in the output.
+	// Maps to: Maven build plugins, Rust build-dependencies.
+	IncludeBuild bool
+
+	// IncludeOptional includes optional dependencies in the output.
+	// Maps to: Maven optional deps, npm optionalDependencies.
+	IncludeOptional bool
+
 	driverOptions map[string]any
 }
 

--- a/dependencies/implementation.go
+++ b/dependencies/implementation.go
@@ -105,10 +105,13 @@ func (di *defaultImplementation) ExtractCodeBases(
 			}
 
 			nl, err := d.Extract(&api.DecomposerOptions{
-				WorkDir:    cbPath,
-				Version:    ver,
-				CommitHash: hashHex,
-				Networking: opts.Networking,
+				WorkDir:         cbPath,
+				Version:         ver,
+				CommitHash:      hashHex,
+				Networking:      opts.Networking,
+				IncludeDev:      opts.IncludeDev,
+				IncludeBuild:    opts.IncludeBuild,
+				IncludeOptional: opts.IncludeOptional,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("from %q with %T: %w", cbPath, d, err)

--- a/dependencies/unpacker.go
+++ b/dependencies/unpacker.go
@@ -72,6 +72,15 @@ type Options struct {
 	// Defaults to NetworkEssential.
 	Networking api.NetworkLevel
 
+	// IncludeDev includes development/test dependencies.
+	IncludeDev bool
+
+	// IncludeBuild includes build tool dependencies.
+	IncludeBuild bool
+
+	// IncludeOptional includes optional dependencies.
+	IncludeOptional bool
+
 	logger *slog.Logger
 }
 

--- a/docs/decomposers/README.md
+++ b/docs/decomposers/README.md
@@ -53,6 +53,39 @@ decomposers uniformly.
 | **Rust:** local parsing (Cargo.toml/lock) | works | works | works |
 | **Rust:** crates.io API (enrichment) | skip | yes | yes |
 
+## Dependency inclusion flags
+
+By default, only production/compile dependencies are included in the
+output. Three flags control the inclusion of additional dependency types:
+
+| Flag | CLI | Default | Description |
+|------|-----|---------|-------------|
+| `IncludeDev` | `--include-dev` | `false` | Include development and test dependencies |
+| `IncludeBuild` | `--include-build` | `false` | Include build tool dependencies |
+| `IncludeOptional` | `--include-optional` | `false` | Include optional dependencies |
+
+### Per-decomposer mapping
+
+| Flag | Go | Maven | npm | Rust |
+|------|-------|-------|-----|------|
+| `--include-dev` | _(no-op)_ | test-scoped deps | `devDependencies` | `[dev-dependencies]` |
+| `--include-build` | _(no-op)_ | `<build><plugins>` | _(no-op)_ | `[build-dependencies]` |
+| `--include-optional` | _(no-op)_ | `<optional>true</optional>` | `optionalDependencies` | _(no-op)_ |
+
+**Notes:**
+
+- Go modules do not distinguish dependency types in `go.mod`, so all
+  three flags are no-ops for the Go decomposer.
+- Maven's scope transitivity rules still apply: a test-scoped dependency
+  declared by one of your compile-scoped dependencies will never be
+  included, even with `--include-dev`. The flag only affects dependencies
+  declared directly in your own POM (or resolved at the current project
+  level).
+- npm's `peerDependencies` are not covered by these flags and remain
+  a decomposer-specific option (`IncludePeerDependencies`).
+- Maven's `provided` scope is not covered by these flags and remains
+  a decomposer-specific option (`IncludeProvided`).
+
 ## Per-decomposer docs
 
 See the individual pages linked in the table above for implementation

--- a/docs/decomposers/golang.md
+++ b/docs/decomposers/golang.md
@@ -45,6 +45,13 @@
 | `HTTPClient` | `*http.Client` | _(default)_ | Custom HTTP client (for testing) |
 | `Concurrency` | `int` | `10` | Parallel proxy/deps.dev requests |
 
+## Dependency types
+
+Go modules do not distinguish between production, dev, build, or optional
+dependencies in `go.mod`. All three common flags (`--include-dev`,
+`--include-build`, `--include-optional`) are no-ops for the Go decomposer.
+All declared dependencies are always included.
+
 ## Strengths
 
 - No external tooling needed -- does not shell out to `go`.

--- a/docs/decomposers/maven.md
+++ b/docs/decomposers/maven.md
@@ -41,9 +41,21 @@
 | `IncludeTest` | `bool` | `false` | Include test-scoped dependencies |
 | `IncludeProvided` | `bool` | `false` | Include provided-scoped dependencies |
 | `IncludeOptional` | `bool` | `false` | Include optional dependencies |
+| `IncludeBuild` | `bool` | `false` | Include build plugins as dependencies |
 
 Artifact download for SHA-256/SHA-512 computation is controlled by the
 top-level `Networking` setting (`NetworkFull`).
+
+## Dependency types
+
+| Common flag | Maven equivalent | What it includes |
+|-------------|-----------------|------------------|
+| `--include-dev` | `IncludeTest` | Dependencies with `<scope>test</scope>` declared in the project's own POM. Maven's transitivity rules still apply: test-scoped transitive deps from compile-scoped dependencies are never included. |
+| `--include-build` | `IncludeBuild` | Plugins from `<build><plugins>` and `<build><pluginManagement>`. Only plugins with an explicit version are included. Plugins without a groupId default to `org.apache.maven.plugins`. Edge type: `buildDependency`. |
+| `--include-optional` | `IncludeOptional` | Dependencies with `<optional>true</optional>`. Edge type: `optionalDependency`. |
+
+The `provided` scope (`IncludeProvided`) is a decomposer-specific option
+not mapped to any common flag.
 
 ## Strengths
 

--- a/docs/decomposers/npm.md
+++ b/docs/decomposers/npm.md
@@ -37,8 +37,23 @@
 
 ## Options
 
-The npm decomposer currently has no ecosystem-specific options beyond
-the common `DecomposerOptions`.
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `IncludeDevDependencies` | `bool` | `false` | Include dev dependencies |
+| `IncludeOptionalDependencies` | `bool` | `false` | Include optional dependencies |
+| `IncludePeerDependencies` | `bool` | `false` | Include peer dependencies |
+| `IgnoreNodeModulesCodebases` | `bool` | `true` | Ignore package-lock.json in node_modules |
+
+## Dependency types
+
+| Common flag | npm equivalent | What it includes |
+|-------------|---------------|------------------|
+| `--include-dev` | `IncludeDevDependencies` | Packages listed in `devDependencies` in `package.json`. These are direct dependencies only — transitive deps of dev dependencies are still included if they are also reachable from production deps. Edge type: `devDependency`. |
+| `--include-build` | _(no-op)_ | npm does not have a separate build dependency concept. |
+| `--include-optional` | `IncludeOptionalDependencies` | Packages listed in `optionalDependencies` in `package.json`. Edge type: `optionalDependency`. |
+
+`peerDependencies` are not covered by the common flags and remain a
+decomposer-specific option.
 
 ## Strengths
 

--- a/docs/decomposers/rust.md
+++ b/docs/decomposers/rust.md
@@ -47,6 +47,14 @@
 | `IncludeBuildDependencies` | `bool` | `false` | Include build dependencies |
 | `Concurrency` | `int` | `10` | Parallel crates.io API requests |
 
+## Dependency types
+
+| Common flag | Rust equivalent | What it includes |
+|-------------|----------------|------------------|
+| `--include-dev` | `IncludeDevDependencies` | Crates listed in `[dev-dependencies]` in `Cargo.toml`. These are direct dev dependencies only — the type is determined by checking `Cargo.toml` sections since `Cargo.lock` does not distinguish dependency types. Edge type: `devDependency`. |
+| `--include-build` | `IncludeBuildDependencies` | Crates listed in `[build-dependencies]` in `Cargo.toml`. These are typically proc-macro crates or build script helpers. Edge type: `buildDependency`. |
+| `--include-optional` | _(no-op)_ | Cargo's `optional = true` flag on dependencies is related to feature gates, not optional installation. Not currently mapped. |
+
 ## Strengths
 
 - **Rich metadata from crates.io.** Every dependency gets license,

--- a/internal/cmd/extract.go
+++ b/internal/cmd/extract.go
@@ -40,6 +40,9 @@ type extractOptions struct {
 	Sign                 bool
 	IgnoreExtraCodebases bool
 	MultipleOutputs      bool
+	IncludeDev           bool
+	IncludeBuild         bool
+	IncludeOptional      bool
 	Codebase             string
 	OutputPath           string
 	OutputPrefix         string
@@ -96,6 +99,18 @@ func (ro *extractOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(
 		&ro.Networking, "networking", "essential",
 		"network access level: essential (default), full, or disabled",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&ro.IncludeDev, "include-dev", false, "include development/test dependencies",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&ro.IncludeBuild, "include-build", false, "include build tool dependencies",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&ro.IncludeOptional, "include-optional", false, "include optional dependencies",
 	)
 
 	cmd.PersistentFlags().BoolVar(
@@ -207,6 +222,11 @@ to the current directory.
 
 			// Filter to a specific codebase if provided
 			unpacker.Options.CodebaseFilter = opts.Codebase
+
+			// Set dependency inclusion options
+			unpacker.Options.IncludeDev = opts.IncludeDev
+			unpacker.Options.IncludeBuild = opts.IncludeBuild
+			unpacker.Options.IncludeOptional = opts.IncludeOptional
 
 			// Set networking level
 			switch opts.Networking {

--- a/source/maven/decomposer.go
+++ b/source/maven/decomposer.go
@@ -54,6 +54,17 @@ func (d *Decomposer) Requirements(_ *api.DecomposerOptions) []api.Requirement {
 func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error) {
 	dOpts := d.getOptions(opts)
 
+	// Apply common dependency inclusion options
+	if opts.IncludeDev {
+		dOpts.IncludeTest = true
+	}
+	if opts.IncludeBuild {
+		dOpts.IncludeBuild = true
+	}
+	if opts.IncludeOptional {
+		dOpts.IncludeOptional = true
+	}
+
 	// 1. Parse local pom.xml
 	pom, err := ParsePomXML(opts.WorkDir)
 	if err != nil {

--- a/source/npm/decomposer_test.go
+++ b/source/npm/decomposer_test.go
@@ -248,7 +248,9 @@ func TestDecomposerExtract(t *testing.T) {
 
 			d := New()
 			opts := &api.DecomposerOptions{
-				WorkDir: tc.workDir,
+				WorkDir:         tc.workDir,
+				IncludeDev:      true,
+				IncludeOptional: true,
 			}
 
 			nl, err := d.Extract(opts)
@@ -403,10 +405,12 @@ func TestCompareWithNpmLs(t *testing.T) {
 				t.Skip("npm ls returned no packages - skipping comparison")
 			}
 
-			// Extract using our implementation
+			// Extract using our implementation (include all dep types for comparison)
 			d := New()
 			opts := &api.DecomposerOptions{
-				WorkDir: tc.workDir,
+				WorkDir:         tc.workDir,
+				IncludeDev:      true,
+				IncludeOptional: true,
 			}
 			nl, err := d.Extract(opts)
 			require.NoError(t, err)
@@ -473,7 +477,8 @@ func TestDevDependencyEdges(t *testing.T) {
 
 	d := New()
 	opts := &api.DecomposerOptions{
-		WorkDir: "testdata/k8s.io",
+		WorkDir:    "testdata/k8s.io",
+		IncludeDev: true,
 	}
 
 	nl, err := d.Extract(opts)

--- a/source/npm/tree.go
+++ b/source/npm/tree.go
@@ -66,7 +66,7 @@ func (dt *DependencyTree) Build(opts *api.DecomposerOptions) (*sbom.NodeList, er
 
 	// Build the dependency tree from the root's direct dependencies
 	visited := make(map[string]bool)
-	if err := dt.buildFromRoot(nl, rootNode, visited); err != nil {
+	if err := dt.buildFromRoot(nl, rootNode, visited, opts); err != nil {
 		return nil, fmt.Errorf("building dependency tree: %w", err)
 	}
 
@@ -74,9 +74,17 @@ func (dt *DependencyTree) Build(opts *api.DecomposerOptions) (*sbom.NodeList, er
 }
 
 // buildFromRoot builds the dependency tree starting from direct dependencies.
-func (dt *DependencyTree) buildFromRoot(nl *sbom.NodeList, rootNode *sbom.Node, visited map[string]bool) error {
+func (dt *DependencyTree) buildFromRoot(nl *sbom.NodeList, rootNode *sbom.Node, visited map[string]bool, opts *api.DecomposerOptions) error {
 	// Process direct dependencies from package.json
 	for depName, depType := range dt.directDeps {
+		// Filter by dependency type based on common options
+		if depType == DepTypeDev && !opts.IncludeDev {
+			continue
+		}
+		if depType == DepTypeOptional && !opts.IncludeOptional {
+			continue
+		}
+
 		depPath := dt.resolveDependencyPath("", depName)
 		if depPath == "" {
 			continue

--- a/source/rust/decomposer.go
+++ b/source/rust/decomposer.go
@@ -66,11 +66,17 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 		return nil, fmt.Errorf("parsing Cargo.lock: %w", err)
 	}
 
-	// Get decomposer-specific options
+	// Get decomposer-specific options and apply common flags
 	dOpts := d.getOptions(opts)
+	if opts.IncludeDev {
+		dOpts.IncludeDevDependencies = true
+	}
+	if opts.IncludeBuild {
+		dOpts.IncludeBuildDependencies = true
+	}
 
 	// Build the dependency tree
-	tree := NewDependencyTree(cargoToml, cargoLock)
+	tree := NewDependencyTree(cargoToml, cargoLock, dOpts)
 
 	// Build the protobom NodeList
 	nl, err := tree.Build(opts)

--- a/source/rust/decomposer_test.go
+++ b/source/rust/decomposer_test.go
@@ -376,7 +376,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 	d := New()
 	opts := &api.DecomposerOptions{
-		WorkDir: tmpDir,
+		WorkDir:      tmpDir,
+		IncludeDev:   true,
+		IncludeBuild: true,
 	}
 
 	nl, err := d.Extract(opts)
@@ -391,6 +393,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 	// We can verify by checking that nodes are properly connected
 	roots := nl.GetRootElements()
 	require.Len(t, roots, 1)
+
+	// Without dev/build, only the normal dep should be included
+	optsNoDevBuild := &api.DecomposerOptions{
+		WorkDir: tmpDir,
+	}
+	nl2, err := d.Extract(optsNoDevBuild)
+	require.NoError(t, err)
+	require.Len(t, nl2.GetNodes(), 2) // root + normal-dep only
 }
 
 // TestListDependencies tests the helper function for debugging.
@@ -403,7 +413,7 @@ func TestListDependencies(t *testing.T) {
 	lock, err := ParseCargoLock("testdata/simple")
 	require.NoError(t, err)
 
-	tree := NewDependencyTree(toml, lock)
+	tree := NewDependencyTree(toml, lock, &Options{})
 	deps := tree.ListDependencies()
 
 	// Should be sorted
@@ -441,7 +451,7 @@ func TestEnrich(t *testing.T) {
 	lock, err := ParseCargoLock("testdata/simple")
 	require.NoError(t, err)
 
-	tree := NewDependencyTree(toml, lock)
+	tree := NewDependencyTree(toml, lock, &Options{})
 	nl, err := tree.Build(&api.DecomposerOptions{WorkDir: "testdata/simple"})
 	require.NoError(t, err)
 

--- a/source/rust/tree.go
+++ b/source/rust/tree.go
@@ -21,6 +21,7 @@ import (
 type DependencyTree struct {
 	cargoToml *CargoToml
 	cargoLock *CargoLock
+	opts      *Options
 
 	// Indexes for quick lookup
 	pkgByKey  map[PackageKey]*LockPackage
@@ -34,12 +35,13 @@ type DependencyTree struct {
 }
 
 // NewDependencyTree creates a new dependency tree from parsed Cargo files.
-func NewDependencyTree(toml *CargoToml, lock *CargoLock) *DependencyTree {
+func NewDependencyTree(toml *CargoToml, lock *CargoLock, opts *Options) *DependencyTree {
 	pkgByKey, pkgByName := lock.BuildPackageIndex()
 
 	return &DependencyTree{
 		cargoToml:  toml,
 		cargoLock:  lock,
+		opts:       opts,
 		pkgByKey:   pkgByKey,
 		pkgByName:  pkgByName,
 		directDeps: toml.GetDirectDependencies(),
@@ -124,8 +126,14 @@ func (dt *DependencyTree) buildSubtree(nl *sbom.NodeList, pkg *LockPackage, pare
 			dt.nodeCache[depKey] = depNode
 		}
 
-		// Determine the edge type based on how we reached this dependency
+		// Determine the edge type and filter based on options
 		edgeType := dt.determineEdgeType(pkg, depPkg)
+		if edgeType == sbom.Edge_devDependency && !dt.opts.IncludeDevDependencies {
+			continue
+		}
+		if edgeType == sbom.Edge_buildDependency && !dt.opts.IncludeBuildDependencies {
+			continue
+		}
 
 		// Relate the dependency to its parent
 		if err := nl.RelateNodeAtID(depNode, parentNode.GetId(), edgeType); err != nil {


### PR DESCRIPTION
This PR adds `--include-X` flags to `extract` to control if the depednedncy tree has build, dev and optional dependencies.

The decomposers more or less had support for this but now the behave in the same way controlled by the main API options.