### PR TITLE
Add --include-X flags to SBOM subcommand

### DIFF
--- a/internal/cmd/filter.go
+++ b/internal/cmd/filter.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+// filterNodeListByEdgeType removes nodes from the NodeList that are only
+// reachable via excluded edge types. A node is removed only if ALL edges
+// pointing to it are of excluded types — if any included edge also
+// reaches the node, it is kept.
+func filterNodeListByEdgeType(nl *sbom.NodeList, opts *sbomOptions) {
+	// Build the set of excluded edge types based on options
+	excluded := make(map[sbom.Edge_Type]struct{})
+	if !opts.IncludeDev {
+		excluded[sbom.Edge_devDependency] = struct{}{}
+	}
+	if !opts.IncludeBuild {
+		excluded[sbom.Edge_buildDependency] = struct{}{}
+	}
+	if !opts.IncludeOptional {
+		excluded[sbom.Edge_optionalDependency] = struct{}{}
+	}
+
+	if len(excluded) == 0 {
+		return // nothing to filter
+	}
+
+	// Track which node IDs are targets of excluded-only edges vs included edges
+	includedTargets := make(map[string]struct{})
+	excludedTargets := make(map[string]struct{})
+
+	for _, edge := range nl.GetEdges() {
+		_, isExcluded := excluded[edge.GetType()]
+		for _, toID := range edge.GetTo() {
+			if isExcluded {
+				excludedTargets[toID] = struct{}{}
+			} else {
+				includedTargets[toID] = struct{}{}
+			}
+		}
+	}
+
+	// Collect IDs to remove: nodes that appear only in excluded edges
+	var toRemove []string
+	for id := range excludedTargets {
+		if _, kept := includedTargets[id]; !kept {
+			toRemove = append(toRemove, id)
+		}
+	}
+
+	if len(toRemove) > 0 {
+		nl.RemoveNodes(toRemove)
+	}
+}

--- a/internal/cmd/filter_test.go
+++ b/internal/cmd/filter_test.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestNodeList creates a NodeList with a root and four dependencies,
+// each connected via a different edge type:
+//
+//	root --dependsOn--> prod-dep
+//	root --devDependency--> dev-dep
+//	root --buildDependency--> build-dep
+//	root --optionalDependency--> optional-dep
+//	root --dependsOn--> shared-dep
+//	root --devDependency--> shared-dep  (shared-dep reached by both)
+func buildTestNodeList() *sbom.NodeList {
+	nl := sbom.NewNodeList()
+
+	root := &sbom.Node{Id: "root", Name: "my-app", Version: "1.0.0"}
+	prodDep := &sbom.Node{Id: "prod", Name: "prod-dep", Version: "1.0"}
+	devDep := &sbom.Node{Id: "dev", Name: "dev-dep", Version: "1.0"}
+	buildDep := &sbom.Node{Id: "build", Name: "build-dep", Version: "1.0"}
+	optDep := &sbom.Node{Id: "opt", Name: "optional-dep", Version: "1.0"}
+	sharedDep := &sbom.Node{Id: "shared", Name: "shared-dep", Version: "1.0"}
+
+	nl.AddRootNode(root)
+
+	//nolint:errcheck,gosec // test helper — these calls always succeed with valid node IDs
+	nl.RelateNodeAtID(prodDep, "root", sbom.Edge_dependsOn)
+	//nolint:errcheck,gosec
+	nl.RelateNodeAtID(devDep, "root", sbom.Edge_devDependency)
+	//nolint:errcheck,gosec
+	nl.RelateNodeAtID(buildDep, "root", sbom.Edge_buildDependency)
+	//nolint:errcheck,gosec
+	nl.RelateNodeAtID(optDep, "root", sbom.Edge_optionalDependency)
+	//nolint:errcheck,gosec
+	nl.RelateNodeAtID(sharedDep, "root", sbom.Edge_dependsOn)
+	nl.AddEdge(&sbom.Edge{
+		Type: sbom.Edge_devDependency,
+		From: "root",
+		To:   []string{"shared"},
+	})
+
+	return nl
+}
+
+func nodeNames(nl *sbom.NodeList) map[string]bool {
+	names := make(map[string]bool)
+	for _, n := range nl.GetNodes() {
+		names[n.GetName()] = true
+	}
+	return names
+}
+
+func TestFilterAllIncluded(t *testing.T) {
+	t.Parallel()
+	nl := buildTestNodeList()
+	opts := &sbomOptions{IncludeDev: true, IncludeBuild: true, IncludeOptional: true}
+
+	filterNodeListByEdgeType(nl, opts)
+
+	names := nodeNames(nl)
+	require.Len(t, names, 6) // root + 5 deps
+	require.True(t, names["prod-dep"])
+	require.True(t, names["dev-dep"])
+	require.True(t, names["build-dep"])
+	require.True(t, names["optional-dep"])
+	require.True(t, names["shared-dep"])
+}
+
+func TestFilterExcludeDev(t *testing.T) {
+	t.Parallel()
+	nl := buildTestNodeList()
+	opts := &sbomOptions{IncludeDev: false, IncludeBuild: true, IncludeOptional: true}
+
+	filterNodeListByEdgeType(nl, opts)
+
+	names := nodeNames(nl)
+	require.True(t, names["prod-dep"], "prod dep should remain")
+	require.False(t, names["dev-dep"], "dev dep should be removed")
+	require.True(t, names["build-dep"], "build dep should remain")
+	require.True(t, names["optional-dep"], "optional dep should remain")
+	require.True(t, names["shared-dep"], "shared dep should remain (also reachable via dependsOn)")
+}
+
+func TestFilterExcludeBuild(t *testing.T) {
+	t.Parallel()
+	nl := buildTestNodeList()
+	opts := &sbomOptions{IncludeDev: true, IncludeBuild: false, IncludeOptional: true}
+
+	filterNodeListByEdgeType(nl, opts)
+
+	names := nodeNames(nl)
+	require.True(t, names["prod-dep"])
+	require.True(t, names["dev-dep"])
+	require.False(t, names["build-dep"], "build dep should be removed")
+	require.True(t, names["optional-dep"])
+	require.True(t, names["shared-dep"])
+}
+
+func TestFilterExcludeOptional(t *testing.T) {
+	t.Parallel()
+	nl := buildTestNodeList()
+	opts := &sbomOptions{IncludeDev: true, IncludeBuild: true, IncludeOptional: false}
+
+	filterNodeListByEdgeType(nl, opts)
+
+	names := nodeNames(nl)
+	require.True(t, names["prod-dep"])
+	require.True(t, names["dev-dep"])
+	require.True(t, names["build-dep"])
+	require.False(t, names["optional-dep"], "optional dep should be removed")
+	require.True(t, names["shared-dep"])
+}
+
+func TestFilterExcludeAll(t *testing.T) {
+	t.Parallel()
+	nl := buildTestNodeList()
+	opts := &sbomOptions{IncludeDev: false, IncludeBuild: false, IncludeOptional: false}
+
+	filterNodeListByEdgeType(nl, opts)
+
+	names := nodeNames(nl)
+	// Only root, prod-dep, and shared-dep (also reachable via dependsOn) remain
+	require.True(t, names["my-app"], "root should remain")
+	require.True(t, names["prod-dep"], "prod dep should remain")
+	require.True(t, names["shared-dep"], "shared dep should remain (reachable via dependsOn)")
+	require.False(t, names["dev-dep"], "dev dep should be removed")
+	require.False(t, names["build-dep"], "build dep should be removed")
+	require.False(t, names["optional-dep"], "optional dep should be removed")
+}
+
+func TestFilterNothingExcluded(t *testing.T) {
+	t.Parallel()
+	// All flags true means no filtering happens
+	nl := buildTestNodeList()
+	originalCount := len(nl.GetNodes())
+	opts := &sbomOptions{IncludeDev: true, IncludeBuild: true, IncludeOptional: true}
+
+	filterNodeListByEdgeType(nl, opts)
+
+	require.Len(t, nl.GetNodes(), originalCount)
+}

--- a/internal/cmd/sbom.go
+++ b/internal/cmd/sbom.go
@@ -18,10 +18,13 @@ import (
 )
 
 type sbomOptions struct {
-	Path   string
-	Format string
-	Attest bool
-	Sign   bool
+	Path            string
+	Format          string
+	Attest          bool
+	Sign            bool
+	IncludeDev      bool
+	IncludeBuild    bool
+	IncludeOptional bool
 }
 
 // Validates the options in context with arguments
@@ -64,6 +67,18 @@ func (ro *sbomOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
 		&ro.Sign, "sign", false, "sign the attestation into a sigstore bundle (implies --attest)",
 	)
+
+	cmd.PersistentFlags().BoolVar(
+		&ro.IncludeDev, "include-dev", true, "include development/test dependencies (default: true for SBOM reading)",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&ro.IncludeBuild, "include-build", true, "include build tool dependencies (default: true for SBOM reading)",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&ro.IncludeOptional, "include-optional", true, "include optional dependencies (default: true for SBOM reading)",
+	)
 }
 
 func addSBOM(parent *cobra.Command) {
@@ -102,6 +117,9 @@ Unpack sbom takes an SBOM document and returns dependency data from its contents
 			if nodelist == nil {
 				return errors.New("no dependency data found")
 			}
+
+			// Filter out excluded dependency types
+			filterNodeListByEdgeType(nodelist, opts)
 
 			var format formats.Format
 


### PR DESCRIPTION
This adds the `--include-x` flags to the `unpack sbom` command to even out sbom and extract.

The main difference is that here, all flags default to true as the data is alread captured in the SBOM.