### PR TITLE
Fix flakyness on http transients

### DIFF
--- a/source/maven/decomposer_test.go
+++ b/source/maven/decomposer_test.go
@@ -33,6 +33,22 @@ func (f *failingAgentImpl) SendHeadRequest(_ *http.Client, _ string) (*http.Resp
 	return nil, fmt.Errorf("not implemented")
 }
 
+// transientFailAgentImpl simulates a transient network failure (no HTTP
+// response) for all requests, as opposed to a definitive 404.
+type transientFailAgentImpl struct{}
+
+func (f *transientFailAgentImpl) SendGetRequest(_ *http.Client, url string) (*http.Response, error) {
+	return nil, fmt.Errorf("connection refused: %s", url)
+}
+
+func (f *transientFailAgentImpl) SendPostRequest(_ *http.Client, _ string, _ []byte, _ string) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *transientFailAgentImpl) SendHeadRequest(_ *http.Client, _ string) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func TestDecomposerDefaultOptions(t *testing.T) {
 	t.Parallel()
 	d := New()
@@ -87,6 +103,28 @@ func TestDecomposerExtractSimple(t *testing.T) {
 	// Test and provided deps should be excluded by default
 	nodes := nl.GetNodes()
 	require.GreaterOrEqual(t, len(nodes), 3) // root + guava + commons-lang3
+}
+
+// TestDecomposerExtractTransientFails verifies that a transient fetch failure
+// (after retries) fails the extraction rather than silently producing an
+// incomplete tree. This is the counterpart to TestDecomposerExtractSimple,
+// where a definitive 404 is tolerated.
+func TestDecomposerExtractTransientFails(t *testing.T) {
+	t.Parallel()
+
+	pom, err := ParsePomXML("testdata/simple")
+	require.NoError(t, err)
+
+	resolver := NewResolver(&Options{RepoURL: "https://unused.test", Concurrency: 1})
+	resolver.Agent = resolver.Agent.WithRetries(0)
+	resolver.Agent.SetImplementation(&transientFailAgentImpl{})
+
+	effective, err := resolver.ResolveEffectivePOM(pom)
+	require.NoError(t, err)
+
+	dt := NewDependencyTree(effective, resolver, &defaultOptions)
+	err = dt.Build()
+	require.Error(t, err, "transient fetch failure should fail the build")
 }
 
 func TestCanDecompose(t *testing.T) {

--- a/source/maven/resolver.go
+++ b/source/maven/resolver.go
@@ -6,8 +6,10 @@ package maven
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +17,15 @@ import (
 	"github.com/carabiner-dev/hasher"
 	khttp "sigs.k8s.io/release-utils/http"
 )
+
+// ErrNotFound is returned when a resource (POM, metadata) is definitively
+// absent from a repository (HTTP 404). Maven Central is immutable, so a 404
+// almost never means the artifact was removed; it usually means the artifact
+// lives in a different repository or the coordinate is wrong. Callers should
+// treat it as a tolerable "not in this repo" signal rather than a hard failure,
+// distinguishing it from transient/network errors (which are fatal once the
+// HTTP agent's retries are exhausted).
+var ErrNotFound = errors.New("resource not found in repository")
 
 const (
 	defaultRepoURL     = "https://repo1.maven.org/maven2"
@@ -77,7 +88,7 @@ func (r *Resolver) FetchPOMFrom(groupID, artifactID, version, repoURL string) (*
 	r.mu.RUnlock()
 
 	url := r.pomURLFrom(groupID, artifactID, version, repoURL)
-	data, err := r.Agent.Get(url)
+	data, err := r.get(url)
 	if err != nil {
 		return nil, fmt.Errorf("fetching POM %s: %w", key, err)
 	}
@@ -92,6 +103,27 @@ func (r *Resolver) FetchPOMFrom(groupID, artifactID, version, repoURL string) (*
 	r.mu.Unlock()
 
 	return pom, nil
+}
+
+// get fetches a URL through the HTTP agent (which retries transient failures),
+// translating a definitive 404 into ErrNotFound so callers can tell a
+// "not in this repo" miss apart from a transient/network failure. The agent's
+// WithFailOnHTTPError surfaces other non-2xx statuses as plain errors.
+func (r *Resolver) get(url string) ([]byte, error) {
+	resp, err := r.Agent.GetRequest(url)
+	if resp != nil {
+		defer resp.Body.Close() //nolint:errcheck // read-only body
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, url)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %s for %s", resp.Status, url)
+	}
+	return io.ReadAll(resp.Body)
 }
 
 // effectiveRepoURL returns override when non-empty (trimmed), else r.RepoURL.

--- a/source/maven/tree.go
+++ b/source/maven/tree.go
@@ -4,6 +4,7 @@
 package maven
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -178,11 +179,26 @@ func (dt *DependencyTree) Build() error {
 		var licenses []License
 		var transitiveDeps []Dependency
 		if dt.resolver != nil && version != "" {
+			// Fetching a dependency's POM is what lets us discover its
+			// transitive dependencies.
 			depPOM, err := dt.resolver.FetchPOMFrom(dep.GroupID, dep.ArtifactID, version, coord.RepoURL)
-			if err == nil {
+			switch {
+			case err == nil:
+				// proceed to extract transitive deps below
+			case errors.Is(err, ErrNotFound):
+				// The POM isn't in the configured repository (it may be hosted
+				// in a different repo, or the coordinate is off). Tolerate it:
+				// keep the dependency node but skip expanding its transitives.
+				depPOM = nil
+			default:
+				// Transient/network failure after the agent's retries. Failing
+				// here beats returning a silently incomplete tree.
+				return fmt.Errorf("fetching POM for %s: %w", coord.String(), err)
+			}
+
+			if depPOM != nil {
 				// Try to resolve effective POM for accurate data
-				effective, err := dt.resolver.ResolveEffectivePOM(depPOM)
-				if err == nil {
+				if effective, err := dt.resolver.ResolveEffectivePOM(depPOM); err == nil {
 					depPOM = effective
 				}
 				licenses = depPOM.Licenses


### PR DESCRIPTION
This pull request improves the handling of transient and definitive fetch failures when resolving Maven dependencies. It introduces a clear distinction between resources not found (HTTP 404) and transient network errors, ensuring that only definitive misses are tolerated, while transient failures after retries cause the dependency extraction to fail. This results in more reliable and predictable dependency resolution.

**Error handling improvements:**

* Added a new error type `ErrNotFound` to represent definitive 404 "not found" responses, allowing the resolver to distinguish between resources that are truly missing and transient network issues.
* Updated the `get` method in `resolver.go` to translate HTTP 404 responses into `ErrNotFound`, and to surface other HTTP errors appropriately.
* Modified the dependency tree build process to tolerate missing dependencies only when `ErrNotFound` is returned, but to fail on all other errors, including transient/network failures.

**Testing enhancements:**

* Added a new test `TestDecomposerExtractTransientFails` and a supporting `transientFailAgentImpl` agent to verify that transient fetch failures correctly cause the extraction to fail, rather than silently producing an incomplete tree. [[1]](diffhunk://#diff-0813f12d0a386dce397590f2ede3fff1a4459e6e83b03f0a2d1cc5212abd5781R36-R51) [[2]](diffhunk://#diff-0813f12d0a386dce397590f2ede3fff1a4459e6e83b03f0a2d1cc5212abd5781R108-R129)

**Codebase maintenance:**

* Added missing imports for `errors` and `net/http` to support the new error handling logic. [[1]](diffhunk://#diff-aa7d5cd38f2691a04ebedf48a416cfcffba03377891d52c2c0ab98d91f92a340R9-R12) [[2]](diffhunk://#diff-19afce67592d18d298b58c324cae24a4ac6912ddfbcb54f28e5da963dda48e59R7)
* Refactored the POM fetching logic to use the new `get` method, centralizing error handling.