### PR TITLE
Add image subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/carabiner-dev/attestation v0.2.1
 	github.com/carabiner-dev/collector v0.3.7
+	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/protograph v0.0.0-20260117204235-4dc9de9c0db5
 	github.com/carabiner-dev/signer v0.5.2
@@ -40,7 +41,6 @@ require (
 	github.com/avast/retry-go/v4 v4.7.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/carabiner-dev/command v0.3.1 // indirect
 	github.com/carabiner-dev/openeox v1.0.0-pre.1 // indirect
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 // indirect
 	github.com/carabiner-dev/policy v0.5.0 // indirect

--- a/internal/cmd/extract.go
+++ b/internal/cmd/extract.go
@@ -16,7 +16,6 @@ import (
 	"github.com/carabiner-dev/protograph"
 	"github.com/carabiner-dev/signer"
 	"github.com/fatih/color"
-	"github.com/protobom/protobom/pkg/formats"
 	"github.com/spf13/cobra"
 
 	api "github.com/carabiner-dev/unpack/api/v1"
@@ -31,13 +30,11 @@ const (
 )
 
 type extractOptions struct {
+	formatOptions
+	filesOptions
 	IgnorePatterns       []string
 	Path                 string
-	Format               string
 	Networking           string
-	IndexFiles           bool
-	Attest               bool
-	Sign                 bool
 	IgnoreExtraCodebases bool
 	MultipleOutputs      bool
 	IncludeDev           bool
@@ -52,26 +49,16 @@ var validFormats = []string{formatSPDX, formatCDX, formatCDXS, formatTree}
 
 // Validates the options in context with arguments
 func (ro *extractOptions) Validate() error {
-	errs := []error{}
+	errs := []error{
+		ro.formatOptions.Validate(),
+		ro.filesOptions.Validate(),
+	}
 	if ro.Path == "" {
 		errs = append(errs, errors.New("path not defined"))
 	}
 
-	if !slices.Contains(validFormats, ro.Format) {
-		errs = append(errs, errors.New("invalid format"))
-	}
-
 	if !slices.Contains([]string{"essential", "full", "disabled"}, ro.Networking) {
 		errs = append(errs, fmt.Errorf("invalid networking level %q (must be essential, full, or disabled)", ro.Networking))
-	}
-
-	// --sign implies --attest
-	if ro.Sign {
-		ro.Attest = true
-	}
-
-	if ro.Attest && (ro.Format != formatSPDX && ro.Format != formatCDX) {
-		errs = append(errs, fmt.Errorf("attestations can only be generated when output set to SPDX or CycloneDX"))
 	}
 
 	// Tree view can handle only one codebase
@@ -84,16 +71,15 @@ func (ro *extractOptions) Validate() error {
 
 // AddFlags adds the subcommands flags
 func (ro *extractOptions) AddFlags(cmd *cobra.Command) {
+	ro.formatOptions.AddFlags(cmd)
+	ro.filesOptions.AddFlags(cmd)
+
 	cmd.PersistentFlags().StringVarP(
 		&ro.Path, "path", "p", ".", "path to the artifact to unpack",
 	)
 
 	cmd.PersistentFlags().StringSliceVarP(
 		&ro.IgnorePatterns, "ignore", "i", []string{}, "path patterns to ignore from analysis and indexing",
-	)
-
-	cmd.PersistentFlags().StringVarP(
-		&ro.Format, "format", "f", formatTree, fmt.Sprintf("format for the output %+v", validFormats),
 	)
 
 	cmd.PersistentFlags().StringVar(
@@ -111,18 +97,6 @@ func (ro *extractOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVar(
 		&ro.IncludeOptional, "include-optional", false, "include optional dependencies",
-	)
-
-	cmd.PersistentFlags().BoolVar(
-		&ro.IndexFiles, "files", dependencies.DefaultOptions.IndexFiles, "Index all files in codebases",
-	)
-
-	cmd.PersistentFlags().BoolVar(
-		&ro.Attest, "attest", false, "output sboms in an intoto attestation (defaults to format=spdx)",
-	)
-
-	cmd.PersistentFlags().BoolVar(
-		&ro.Sign, "sign", false, "sign the attestation into a sigstore bundle (implies --attest)",
 	)
 
 	cmd.PersistentFlags().BoolVar(
@@ -197,9 +171,7 @@ to the current directory.
 
 			// Default to SPDX when --attest or --sign is used and
 			// --format was not explicitly specified.
-			if (opts.Attest || opts.Sign) && !cmd.Flags().Changed("format") {
-				opts.Format = formatSPDX
-			}
+			opts.DefaultToSPDX(cmd)
 
 			return nil
 		},
@@ -210,7 +182,7 @@ to the current directory.
 			unpacker := dependencies.NewUnpacker()
 
 			// Add all the source files from codebases
-			unpacker.Options.IndexFiles = opts.IndexFiles
+			unpacker.Options.IndexFiles = opts.Files
 
 			// Add any extra paths to ignore
 			unpacker.Options.IgnorePatterns = opts.IgnorePatterns
@@ -336,21 +308,13 @@ func handleCodeBase(ctx context.Context, opts *extractOptions, s *signer.Signer,
 		return errors.New("no dependency data found")
 	}
 
-	var format formats.Format
-
-	switch opts.Format {
-	case formatTree:
+	format, isSbom := opts.ProtobomFormat()
+	if !isSbom {
 		pg := protograph.New()
 		if err := pg.GraphNodeList(nodelist); err != nil {
 			return err
 		}
 		return nil
-	case formatSPDX:
-		format = formats.SPDX23JSON
-	case formatCDXS, formatCDX:
-		format = formats.CDX16JSON
-	default:
-		return fmt.Errorf("invalid format")
 	}
 
 	// Determine the output writer. When an output directory is set,

--- a/internal/cmd/image.go
+++ b/internal/cmd/image.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/carabiner-dev/command/output"
+	"github.com/carabiner-dev/protograph"
+	"github.com/carabiner-dev/signer"
+	"github.com/spf13/cobra"
+
+	"github.com/carabiner-dev/unpack/image"
+)
+
+// imageOptions assembles the reusable option sets shared with extract plus
+// the image-specific bits.
+type imageOptions struct {
+	formatOptions
+	filesOptions
+	Output output.Options
+
+	// Reference is the OCI reference of the image to unpack, taken from
+	// the positional argument.
+	Reference string
+}
+
+// Validate checks the options of all the embedded sets.
+func (io_ *imageOptions) Validate() error {
+	errs := []error{}
+	if io_.Reference == "" {
+		errs = append(errs, errors.New("no image reference specified"))
+	}
+	errs = append(errs,
+		io_.formatOptions.Validate(),
+		io_.filesOptions.Validate(),
+		io_.Output.Validate(),
+	)
+	return errors.Join(errs...)
+}
+
+// AddFlags adds the flags of all the embedded option sets to the command.
+func (io_ *imageOptions) AddFlags(cmd *cobra.Command) {
+	io_.formatOptions.AddFlags(cmd)
+	io_.filesOptions.AddFlags(cmd)
+	io_.Output.AddFlags(cmd)
+}
+
+func addImage(parent *cobra.Command) {
+	opts := &imageOptions{}
+
+	imageCmd := &cobra.Command{
+		Short: "extract the dependency tree of a container image",
+		Long: fmt.Sprintf(`%s image: container image dependency extractor
+
+Unpack image takes the OCI reference of a container image, downloads it,
+squashes its layers into the filesystem a running container would see, and
+extracts the operating system packages installed in it (apk, dpkg and rpm
+databases, including distroless images).
+
+For a single-arch image the result is the image at the top with its packages
+as descendants. For a multi-arch image, the index sits at the top with one
+node per platform image, each carrying its own packages.
+
+By default, dependencies are displayed as an ASCII tree in the terminal but
+the data can be exported as an SPDX or CycloneDX SBOM, wrapped in an in-toto
+attestation, or signed into a sigstore bundle.
+
+Usage patterns:
+  %[1]s image alpine:3.21                  Show the package tree of an image
+  %[1]s image -f spdx alpine:3.21          Output an SPDX SBOM
+  %[1]s image --files -f spdx alpine:3.21  Include the package file lists
+  %[1]s image --attest alpine:3.21         Wrap the SBOM in an attestation
+  %[1]s image --sign -o a.json alpine:3.21 Sign it into a sigstore bundle
+
+`, appname),
+		Use:               "image [flags] REFERENCE",
+		SilenceUsage:      false,
+		PersistentPreRunE: initLogging,
+		Args:              cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.Reference = args[0]
+			opts.DefaultToSPDX(cmd)
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			unpacker := image.NewUnpacker()
+			unpacker.Options.IncludeFiles = opts.Files
+
+			lists, err := unpacker.Extract(cmd.Context(), &image.Reference{Ref: opts.Reference})
+			if err != nil {
+				return fmt.Errorf("extracting image: %w", err)
+			}
+			if len(lists) == 0 || lists[0] == nil {
+				return errors.New("no dependency data found in image")
+			}
+			nodelist := lists[0]
+
+			format, isSbom := opts.ProtobomFormat()
+			if !isSbom {
+				pg := protograph.New()
+				return pg.GraphNodeList(nodelist)
+			}
+
+			w, err := opts.Output.GetWriter()
+			if err != nil {
+				return err
+			}
+			wr := asWriteCloser(w)
+			defer wr.Close() //nolint:errcheck // best-effort close; render errors surface below
+
+			switch {
+			case opts.Sign:
+				err = nodeListToSignedAttestation(signer.NewSigner(), wr, format, nodelist)
+			case opts.Attest:
+				err = nodeListToAttestation(wr, format, nodelist)
+			default:
+				err = nodeListToSbom(wr, format, nodelist)
+			}
+			if err != nil {
+				return fmt.Errorf("rendering SBOM: %w", err)
+			}
+			return nil
+		},
+	}
+
+	opts.AddFlags(imageCmd)
+	parent.AddCommand(imageCmd)
+}
+
+// asWriteCloser adapts a writer to the WriteCloser the renderers expect,
+// without closing writers we don't own (stdout).
+func asWriteCloser(w io.Writer) io.WriteCloser {
+	if w == io.Writer(os.Stdout) {
+		return nopWriteCloser{w}
+	}
+	if wc, ok := w.(io.WriteCloser); ok {
+		return wc
+	}
+	return nopWriteCloser{w}
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }

--- a/internal/cmd/image_test.go
+++ b/internal/cmd/image_test.go
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatOptionsValidate(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		opts    formatOptions
+		wantErr string
+	}{
+		{"default tree", formatOptions{Format: formatTree}, ""},
+		{"spdx", formatOptions{Format: formatSPDX}, ""},
+		{"bogus format", formatOptions{Format: "yaml"}, "invalid format"},
+		{"attest needs sbom format", formatOptions{Format: formatTree, Attest: true}, "attestations can only"},
+		{"attest with cdx", formatOptions{Format: formatCDXS, Attest: true}, ""},
+		{"sign implies attest", formatOptions{Format: formatSPDX, Sign: true}, ""},
+		{"sign with tree fails", formatOptions{Format: formatTree, Sign: true}, "attestations can only"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.opts.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestFormatOptionsSignImpliesAttest(t *testing.T) {
+	t.Parallel()
+	opts := formatOptions{Format: formatSPDX, Sign: true}
+	require.NoError(t, opts.Validate())
+	assert.True(t, opts.Attest)
+}
+
+func TestFormatOptionsDefaultToSPDX(t *testing.T) {
+	t.Parallel()
+	opts := &formatOptions{}
+	cmd := &cobra.Command{}
+	opts.AddFlags(cmd)
+
+	require.NoError(t, cmd.PersistentFlags().Set("attest", "true"))
+	opts.DefaultToSPDX(cmd)
+	assert.Equal(t, formatSPDX, opts.Format)
+
+	// An explicit format is respected.
+	opts2 := &formatOptions{}
+	cmd2 := &cobra.Command{}
+	opts2.AddFlags(cmd2)
+	require.NoError(t, cmd2.PersistentFlags().Set("format", formatCDXS))
+	require.NoError(t, cmd2.PersistentFlags().Set("attest", "true"))
+	opts2.DefaultToSPDX(cmd2)
+	assert.Equal(t, formatCDXS, opts2.Format)
+}
+
+// imageTestDB is a one-package apk database for the CLI round-trip.
+const imageTestDB = `P:musl
+V:1.2.6-r2
+A:x86_64
+T:the musl c library (libc) implementation
+L:MIT
+o:musl
+F:lib
+R:ld-musl-x86_64.so.1
+Z:Q1HDbpApgJLhKPJN6IjaA7wJ3Oa4o=
+`
+
+// pushCmdTestImage pushes a minimal apk-carrying image to an in-memory
+// registry and returns its reference.
+func pushCmdTestImage(t *testing.T) string {
+	t.Helper()
+
+	srv := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	t.Cleanup(srv.Close)
+	host, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range []struct{ name, content string }{
+		{"lib/apk/db/installed", imageTestDB},
+		{"etc/os-release", "ID=alpine\nVERSION_ID=3.24.0\n"},
+	} {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: e.name, Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(e.content)),
+		}))
+		_, err := tw.Write([]byte(e.content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	data := buf.Bytes()
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	})
+	require.NoError(t, err)
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	require.NoError(t, err)
+	img, err = mutate.ConfigFile(img, &v1.ConfigFile{Architecture: "amd64", OS: "linux"})
+	require.NoError(t, err)
+
+	refStr := host.Host + "/test/minialpine:v1"
+	ref, err := name.ParseReference(refStr)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(ref, img))
+	return refStr
+}
+
+// TestImageCommandSPDX runs the image subcommand end to end: pull from a
+// local registry, extract, and write an SPDX SBOM to a file.
+func TestImageCommandSPDX(t *testing.T) {
+	commandLineOpts.logLevel = "info"
+	refStr := pushCmdTestImage(t)
+	outPath := filepath.Join(t.TempDir(), "image.spdx.json")
+
+	root := &cobra.Command{Use: "test"}
+	addImage(root)
+	root.SetArgs([]string{"image", "--format", "spdx", "--output", outPath, refStr})
+	require.NoError(t, root.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(data, &doc))
+	assert.Equal(t, "SPDX-2.3", doc["spdxVersion"])
+
+	out := string(data)
+	assert.Contains(t, out, refStr, "the image node carries the reference")
+	assert.Contains(t, out, "pkg:oci/minialpine@sha256%3A")
+	assert.Contains(t, out, "pkg:apk/alpine/musl@1.2.6-r2")
+}
+
+// TestImageCommandFiles verifies --files flows through to the system
+// decomposers.
+func TestImageCommandFiles(t *testing.T) {
+	commandLineOpts.logLevel = "info"
+	refStr := pushCmdTestImage(t)
+	outPath := filepath.Join(t.TempDir(), "image.spdx.json")
+
+	root := &cobra.Command{Use: "test"}
+	addImage(root)
+	root.SetArgs([]string{"image", "--files", "-f", "spdx", "-o", outPath, refStr})
+	require.NoError(t, root.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "/lib/ld-musl-x86_64.so.1",
+		"the package file list should be in the SBOM")
+}
+
+func TestImageCommandNeedsReference(t *testing.T) {
+	commandLineOpts.logLevel = "info"
+	root := &cobra.Command{Use: "test"}
+	addImage(root)
+	root.SetArgs([]string{"image"})
+	root.SetErr(io.Discard)
+	root.SetOut(io.Discard)
+	require.Error(t, root.Execute())
+}
+
+func TestImageCommandRejectsBadFormat(t *testing.T) {
+	commandLineOpts.logLevel = "info"
+	root := &cobra.Command{Use: "test"}
+	addImage(root)
+	root.SetArgs([]string{"image", "-f", "yaml", "example.com/img:v1"})
+	root.SetErr(io.Discard)
+	root.SetOut(io.Discard)
+	require.ErrorContains(t, root.Execute(), "invalid format")
+}

--- a/internal/cmd/optionsets.go
+++ b/internal/cmd/optionsets.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/carabiner-dev/command"
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/spf13/cobra"
+)
+
+// formatOptions is the reusable options set controlling how extracted
+// dependency data is rendered: the output format plus the attestation and
+// signing toggles, whose validation rules are coupled to it.
+type formatOptions struct {
+	config *command.OptionsSetConfig
+
+	// Format selects the output rendering: an ASCII tree or an SBOM format.
+	Format string
+
+	// Attest wraps the resulting SBOM in an in-toto attestation.
+	Attest bool
+
+	// Sign signs the attestation into a sigstore bundle (implies Attest).
+	Sign bool
+}
+
+var _ command.OptionsSet = (*formatOptions)(nil)
+
+// Config returns the flag configuration of the format options.
+func (fo *formatOptions) Config() *command.OptionsSetConfig {
+	if fo.config == nil {
+		fo.config = &command.OptionsSetConfig{
+			Flags: map[string]command.FlagConfig{
+				"format": {
+					Short: "f",
+					Long:  "format",
+					Help:  fmt.Sprintf("format for the output %+v", validFormats),
+				},
+				"attest": {
+					Long: "attest",
+					Help: "output sboms in an intoto attestation (defaults to format=spdx)",
+				},
+				"sign": {
+					Long: "sign",
+					Help: "sign the attestation into a sigstore bundle (implies --attest)",
+				},
+			},
+		}
+	}
+	return fo.config
+}
+
+// AddFlags adds the format, attest and sign flags to a command.
+func (fo *formatOptions) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(
+		&fo.Format, fo.Config().LongFlag("format"), fo.Config().ShortFlag("format"),
+		formatTree, fo.Config().HelpText("format"),
+	)
+	cmd.PersistentFlags().BoolVar(
+		&fo.Attest, fo.Config().LongFlag("attest"), false, fo.Config().HelpText("attest"),
+	)
+	cmd.PersistentFlags().BoolVar(
+		&fo.Sign, fo.Config().LongFlag("sign"), false, fo.Config().HelpText("sign"),
+	)
+}
+
+// Validate checks the format options, applying the --sign implies --attest
+// rule.
+func (fo *formatOptions) Validate() error {
+	errs := []error{}
+	if !slices.Contains(validFormats, fo.Format) {
+		errs = append(errs, errors.New("invalid format"))
+	}
+
+	// --sign implies --attest
+	if fo.Sign {
+		fo.Attest = true
+	}
+
+	if fo.Attest && (fo.Format != formatSPDX && fo.Format != formatCDX && fo.Format != formatCDXS) {
+		errs = append(errs, errors.New("attestations can only be generated when output set to SPDX or CycloneDX"))
+	}
+	return errors.Join(errs...)
+}
+
+// DefaultToSPDX switches the format to SPDX when attesting or signing was
+// requested but no explicit format was chosen. Call it from PreRun, where
+// the flag change state is known.
+func (fo *formatOptions) DefaultToSPDX(cmd *cobra.Command) {
+	flag := fo.Config().LongFlag("format")
+	if (fo.Attest || fo.Sign) &&
+		!cmd.Flags().Changed(flag) && !cmd.PersistentFlags().Changed(flag) {
+		fo.Format = formatSPDX
+	}
+}
+
+// ProtobomFormat translates the format selection to a protobom serializer
+// format. The boolean reports whether the selection is an SBOM format at
+// all — the tree view returns false.
+func (fo *formatOptions) ProtobomFormat() (formats.Format, bool) {
+	switch fo.Format {
+	case formatSPDX:
+		return formats.SPDX23JSON, true
+	case formatCDX, formatCDXS:
+		return formats.CDX16JSON, true
+	default:
+		return "", false
+	}
+}
+
+// filesOptions is the reusable options set controlling file indexing: when
+// enabled, the files of the unpacked subject are included in the resulting
+// dependency data.
+type filesOptions struct {
+	config *command.OptionsSetConfig
+
+	// Files includes the subject's files in the extracted data.
+	Files bool
+}
+
+var _ command.OptionsSet = (*filesOptions)(nil)
+
+// Config returns the flag configuration of the files options.
+func (fo *filesOptions) Config() *command.OptionsSetConfig {
+	if fo.config == nil {
+		fo.config = &command.OptionsSetConfig{
+			Flags: map[string]command.FlagConfig{
+				"files": {
+					Long: "files",
+					Help: "include all files in the extracted dependency data",
+				},
+			},
+		}
+	}
+	return fo.config
+}
+
+// AddFlags adds the files flag to a command.
+func (fo *filesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(
+		&fo.Files, fo.Config().LongFlag("files"), false, fo.Config().HelpText("files"),
+	)
+}
+
+// Validate checks the files options.
+func (fo *filesOptions) Validate() error { return nil }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -37,9 +37,13 @@ Extract the dependency data from an SBOM:
 
 Same but output the SBOM data in another format:
 
-%s sbom --format=cyclonedx /path/to/sbom.spdx.json 
+%s sbom --format=cyclonedx /path/to/sbom.spdx.json
 
-`, appname, appname, appname, appname),
+Extract the system packages installed in a container image:
+
+%s image alpine:3.21
+
+`, appname, appname, appname, appname, appname),
 	}
 
 	rootCmd.PersistentFlags().StringVar(
@@ -65,6 +69,7 @@ func Execute() {
 	rootCmd := rootCommand()
 
 	addExtract(rootCmd)
+	addImage(rootCmd)
 	addSBOM(rootCmd)
 	addLs(rootCmd)
 	rootCmd.AddCommand(version.WithFont("doom"))


### PR DESCRIPTION
This pull request introduces a significant refactor to how command-line options are handled for output formats and file indexing, and adds a new `image` subcommand for extracting dependencies from container images. The main changes include extracting reusable option sets (`formatOptions`, `filesOptions`), updating the `extract` command to use these sets, and implementing the new `image` command with thorough end-to-end tests. These changes improve code reuse, maintainability, and extend the CLI's capabilities to support container images.

**Refactor: Reusable Option Sets**
- Introduced `formatOptions` and `filesOptions` structs in `internal/cmd/optionsets.go` to encapsulate logic for output format, attestation, signing, and file inclusion flags, including validation and flag registration. This centralizes and simplifies option handling across commands.
- Updated the `extract` command to use these new option sets, removing duplicated flag logic and validation from `internal/cmd/extract.go`. [[1]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR33-L40) [[2]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL55-L76) [[3]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR74-R76) [[4]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL95-L98) [[5]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL116-L127) [[6]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL200-R174) [[7]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL213-R185) [[8]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL339-L353)

**Feature: New Image Subcommand**
- Added a new `image` subcommand in `internal/cmd/image.go` to extract dependency trees from container images, supporting all output formats, attestations, and signing.
- Registered the new subcommand in the CLI root and updated help text to include usage examples for images. [[1]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dL42-R46) [[2]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dR72)

**Testing: End-to-End and Option Validation**
- Added comprehensive tests in `internal/cmd/image_test.go` covering format option validation, attestation/signing logic, and full round-trip extraction from a test image using a local registry.

**Dependency Management**
- Moved `github.com/carabiner-dev/command` from an indirect to a direct dependency in `go.mod`, reflecting its central role in the new options architecture. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R9) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L43)

**Cleanup**
- Removed unused imports (e.g., `github.com/protobom/protobom/pkg/formats`) and legacy flag handling from `internal/cmd/extract.go`. [[1]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL19) [[2]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dR33-L40) [[3]](diffhunk://#diff-263f9f9fa41fbab65fad546acb17b6daa443ad65659d10e8f7ffe111f3777e5dL55-L76)

These changes modernize the CLI's option handling and extend its functionality to support container image analysis with robust testing.