### PR TITLE
Add the file license scanner

### DIFF
--- a/filesystem/file_processor.go
+++ b/filesystem/file_processor.go
@@ -22,5 +22,6 @@ type FileProcessorFactory func() FileProcessor
 // FileProcessors is the list of available file processor factories.
 // Each call produces a fresh instance to avoid shared mutable state.
 var FileProcessors = map[string]FileProcessorFactory{
-	"hash": func() FileProcessor { return processors.NewHasher() },
+	"hash":    func() FileProcessor { return processors.NewHasher() },
+	"license": func() FileProcessor { return processors.NewLicenseScanner() },
 }

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -133,22 +133,6 @@ func (d *Decomposer) readtTree(source fs.FS) ([]string, error) {
 	return fileList, nil
 }
 
-// func (d *Decomposer) ReadLicense() {
-// 	reader, err := di.LicenseReader(opts)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("creating license reader: %w", err)
-// 	}
-
-// 	licenseTag := ""
-// 	lic, err := di.GetDirectoryLicense(reader, dirPath, opts)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("scanning directory for licenses: %w", err)
-// 	}
-// 	if lic != nil {
-// 		licenseTag = lic.LicenseID
-// 	}
-// }
-
 // ignorePatterns compiles the list of gitignore patterns from options and
 // from the gitignore file.
 func (d *Decomposer) ignorePatterns(source fs.FS, dirPath string) ([]gitignore.Pattern, error) {

--- a/filesystem/processors/license.go
+++ b/filesystem/processors/license.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package processors
+
+import (
+	"fmt"
+	"io/fs"
+	"sync"
+
+	classifier "github.com/google/licenseclassifier/v2"
+	"github.com/google/licenseclassifier/v2/assets"
+	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/carabiner-dev/unpack/filesystem/options"
+	"github.com/carabiner-dev/unpack/license"
+)
+
+// The classifier is shared by all scanner instances: building it
+// indexes the embedded license corpus once, and matching is safe for
+// concurrent use.
+var (
+	licenseClassifier     *classifier.Classifier
+	licenseClassifierOnce sync.Once
+	errLicenseClassifier  error
+)
+
+func getLicenseClassifier() (*classifier.Classifier, error) {
+	licenseClassifierOnce.Do(func() {
+		licenseClassifier, errLicenseClassifier = assets.DefaultClassifier()
+	})
+	if errLicenseClassifier != nil {
+		return nil, fmt.Errorf("building license classifier: %w", errLicenseClassifier)
+	}
+	return licenseClassifier, nil
+}
+
+func NewLicenseScanner() *LicenseScanner {
+	return &LicenseScanner{}
+}
+
+// LicenseScanner is a file processor that matches file contents
+// against the license classifier corpus. When a file holds a license,
+// its normalized SPDX identifier is recorded as the node's license
+// and concluded license; files without one are left untouched.
+type LicenseScanner struct{}
+
+func (p *LicenseScanner) Process(_ *options.Options, source fs.FS, node *sbom.Node) error {
+	c, err := getLicenseClassifier()
+	if err != nil {
+		return err
+	}
+
+	// Open the file
+	f, err := source.Open(node.GetFileName())
+	if err != nil {
+		return fmt.Errorf("opening %q: %w", node.GetFileName(), err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	results, err := c.MatchFrom(f)
+	if err != nil {
+		return fmt.Errorf("classifying %q: %w", node.GetFileName(), err)
+	}
+
+	// The classifier also reports header and copyright notice
+	// matches; only full license matches count, and of those the one
+	// matched with the highest confidence wins.
+	name := ""
+	confidence := 0.0
+	for _, match := range results.Matches {
+		if match.MatchType != "License" {
+			continue
+		}
+		if match.Confidence > confidence {
+			confidence = match.Confidence
+			name = match.Name
+		}
+	}
+	if name == "" {
+		return nil
+	}
+
+	id := license.Normalize(name, "")
+	node.Licenses = []string{id}
+	node.LicenseConcluded = id
+	return nil
+}

--- a/filesystem/processors/license_test.go
+++ b/filesystem/processors/license_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package processors
+
+import (
+	"os"
+	"testing"
+
+	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLicenseScannerProcess(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		path    string
+		expect  []string
+		mustErr bool
+	}{
+		{"license", "MIT.txt", []string{"MIT"}, false},
+		{"no-license", "notes.txt", nil, false},
+		{"notfound", "not-existing.txt", nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			node := sbom.NewNode()
+			node.Type = sbom.Node_FILE
+			node.Name = tc.path
+			node.FileName = tc.path
+
+			err := NewLicenseScanner().Process(nil, os.DirFS("testdata"), node)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if len(tc.expect) > 0 {
+				require.Equal(t, tc.expect, node.GetLicenses())
+				require.Equal(t, tc.expect[0], node.GetLicenseConcluded())
+			} else {
+				require.Empty(t, node.GetLicenses())
+				require.Empty(t, node.GetLicenseConcluded())
+			}
+		})
+	}
+}

--- a/filesystem/processors/testdata/MIT.txt
+++ b/filesystem/processors/testdata/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Carabiner Systems, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OR IN CONNECTION WITH
+THE SOFTWARE.

--- a/filesystem/processors/testdata/notes.txt
+++ b/filesystem/processors/testdata/notes.txt
@@ -1,0 +1,2 @@
+Meeting notes: discuss the roadmap for the file scanner and agree on
+the release schedule for the next milestone.


### PR DESCRIPTION
This commit adds the missing file license scanner. When enabled, the file scanner will also scan files to detect license headers and license files in each read file.