### PR TITLE
Add docker-archive input to the image unpacker

### DIFF
--- a/image/archive.go
+++ b/image/archive.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+// extractArchive reads the image out of a docker-archive tarball and
+// routes it through the same squash-and-scan pipeline as pulled images.
+func (u *Unpacker) extractArchive(ctx context.Context, ref *Reference) ([]*sbom.NodeList, error) {
+	refStr, nref, img, err := openArchiveImage(ref)
+	if err != nil {
+		return nil, err
+	}
+	nl, err := u.extractImage(ctx, refStr, nref, img)
+	if err != nil {
+		return nil, err
+	}
+	return []*sbom.NodeList{nl}, nil
+}
+
+// openArchiveImage loads the image from the archive along with the
+// identity its node will carry. Ref selects the image in multi-image
+// archives; without it, single-image archives identify through their
+// RepoTags, falling back to the image digest for untagged archives,
+// which then carry no purl or version.
+func openArchiveImage(ref *Reference) (string, name.Reference, v1.Image, error) {
+	if ref.Ref != "" {
+		tag, err := name.NewTag(ref.Ref)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("parsing image reference %q: %w", ref.Ref, err)
+		}
+		img, err := tarball.ImageFromPath(ref.Archive, &tag)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("reading image %q from %q: %w", ref.Ref, ref.Archive, err)
+		}
+		return ref.Ref, tag, img, nil
+	}
+
+	manifest, err := tarball.LoadManifest(func() (io.ReadCloser, error) { return os.Open(ref.Archive) })
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("reading manifest of %q: %w", ref.Archive, err)
+	}
+	if len(manifest) != 1 {
+		return "", nil, nil, fmt.Errorf(
+			"archive %q holds %d images, set Ref to select one", ref.Archive, len(manifest),
+		)
+	}
+
+	if tags := manifest[0].RepoTags; len(tags) > 0 {
+		tag, err := name.NewTag(tags[0])
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("parsing archive tag %q: %w", tags[0], err)
+		}
+		img, err := tarball.ImageFromPath(ref.Archive, &tag)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("reading image from %q: %w", ref.Archive, err)
+		}
+		return tags[0], tag, img, nil
+	}
+
+	img, err := tarball.ImageFromPath(ref.Archive, nil)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("reading image from %q: %w", ref.Archive, err)
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("reading image digest: %w", err)
+	}
+	return digest.String(), nil, img, nil
+}

--- a/image/archive_test.go
+++ b/image/archive_test.go
@@ -5,6 +5,7 @@ package image
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -18,7 +19,7 @@ import (
 
 // buildArchiveImage assembles the same minimal apk image the registry
 // tests use, without pushing it anywhere.
-func buildArchiveImage(t *testing.T, osRelease string) v1.Image {
+func buildArchiveImage(t *testing.T, osRelease string, extraLayers ...v1.Layer) v1.Image {
 	t.Helper()
 	layer := makeLayer(t,
 		dir("lib"), dir("lib/apk"), dir("lib/apk/db"),
@@ -26,7 +27,7 @@ func buildArchiveImage(t *testing.T, osRelease string) v1.Image {
 		dir("etc"),
 		file("etc/os-release", osRelease),
 	)
-	img := makeImage(t, layer)
+	img := makeImage(t, append([]v1.Layer{layer}, extraLayers...)...)
 	// The config is edited in place: replacing it wholesale would drop
 	// the rootfs diff_ids, which the tarball loader validates.
 	cfg, err := img.ConfigFile()
@@ -83,6 +84,64 @@ func TestExtractArchive(t *testing.T) {
 			assert.Len(t, edge.GetTo(), 2, "both apk packages hang off the image")
 		})
 	}
+}
+
+func TestExtractArchiveRecordLayers(t *testing.T) {
+	t.Parallel()
+
+	extra := makeLayer(t, dir("usr"), file("usr/hello.txt", "hello"))
+	img := buildArchiveImage(t, alpineOSRelease, extra)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.Len(t, layers, 2)
+	wantDiffIDs := make([]string, 0, len(layers))
+	for _, layer := range layers {
+		diffID, err := layer.DiffID()
+		require.NoError(t, err)
+		wantDiffIDs = append(wantDiffIDs, diffID.String())
+	}
+
+	tag, err := name.NewTag("registry.example.com/test/layered:v1")
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "image.tar")
+	require.NoError(t, tarball.MultiWriteToFile(path, map[name.Tag]v1.Image{tag: img}))
+
+	u := NewUnpacker()
+	u.Options.RecordLayers = true
+	lists, err := u.Extract(t.Context(), &Reference{Archive: path})
+	require.NoError(t, err)
+	nl := lists[0]
+	roots := nl.GetRootNodes()
+	require.Len(t, roots, 1)
+	imageID := roots[0].GetId()
+
+	// Everything hanging directly off the image node: the system
+	// packages plus one structural node per layer.
+	contained := []string{}
+	for _, edge := range nl.GetEdges() {
+		if edge.GetFrom() == imageID && edge.GetType() == sbom.Edge_contains {
+			contained = append(contained, edge.GetTo()...)
+		}
+	}
+
+	layerNames := []string{}
+	packages := 0
+	for _, id := range contained {
+		node := nl.GetNodeByID(id)
+		require.NotNil(t, node)
+		if !strings.HasPrefix(node.GetName(), "sha256:") {
+			packages++
+			continue
+		}
+		layerNames = append(layerNames, node.GetName())
+		assert.Equal(t, strings.TrimPrefix(node.GetName(), "sha256:"),
+			node.GetHashes()[int32(sbom.HashAlgorithm_SHA256)])
+		for _, edge := range nl.GetEdges() {
+			assert.NotEqual(t, id, edge.GetFrom(), "layer nodes carry no packages")
+		}
+	}
+	assert.Equal(t, wantDiffIDs, layerNames, "one node per layer, in order")
+	assert.Equal(t, 2, packages, "the apk packages still hang off the image")
 }
 
 func TestExtractArchiveUntagged(t *testing.T) {

--- a/image/archive_test.go
+++ b/image/archive_test.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildArchiveImage assembles the same minimal apk image the registry
+// tests use, without pushing it anywhere.
+func buildArchiveImage(t *testing.T, osRelease string) v1.Image {
+	t.Helper()
+	layer := makeLayer(t,
+		dir("lib"), dir("lib/apk"), dir("lib/apk/db"),
+		file("lib/apk/db/installed", apkDB),
+		dir("etc"),
+		file("etc/os-release", osRelease),
+	)
+	img := makeImage(t, layer)
+	// The config is edited in place: replacing it wholesale would drop
+	// the rootfs diff_ids, which the tarball loader validates.
+	cfg, err := img.ConfigFile()
+	require.NoError(t, err)
+	cfg = cfg.DeepCopy()
+	cfg.Architecture = "amd64"
+	cfg.OS = "linux"
+	img, err = mutate.ConfigFile(img, cfg)
+	require.NoError(t, err)
+	return img
+}
+
+func TestExtractArchive(t *testing.T) {
+	t.Parallel()
+
+	img := buildArchiveImage(t, alpineOSRelease)
+	digest, err := img.Digest()
+	require.NoError(t, err)
+	tag, err := name.NewTag("registry.example.com/test/minialpine:v1")
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "image.tar")
+	require.NoError(t, tarball.MultiWriteToFile(path, map[name.Tag]v1.Image{tag: img}))
+
+	for _, tc := range []struct {
+		name string
+		ref  string
+	}{
+		{"identity from repotags", ""},
+		{"explicit ref", tag.String()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			u := NewUnpacker()
+			lists, err := u.Extract(t.Context(), &Reference{Ref: tc.ref, Archive: path})
+			require.NoError(t, err)
+			require.Len(t, lists, 1)
+			nl := lists[0]
+
+			roots := nl.GetRootNodes()
+			require.Len(t, roots, 1)
+			node := roots[0]
+
+			assert.Equal(t, tag.String(), node.GetName())
+			assert.Equal(t, "v1", node.GetVersion())
+			assert.Equal(t, "linux/amd64", node.GetDescription())
+			assert.Equal(t, digest.Hex, node.GetHashes()[int32(sbom.HashAlgorithm_SHA256)])
+			assert.Contains(t,
+				node.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)],
+				"pkg:oci/minialpine",
+			)
+
+			edge := nl.GetEdgeByType(node.GetId(), sbom.Edge_contains)
+			require.NotNil(t, edge)
+			assert.Len(t, edge.GetTo(), 2, "both apk packages hang off the image")
+		})
+	}
+}
+
+func TestExtractArchiveUntagged(t *testing.T) {
+	t.Parallel()
+
+	img := buildArchiveImage(t, alpineOSRelease)
+	digest, err := img.Digest()
+	require.NoError(t, err)
+	dref, err := name.NewDigest("registry.example.com/test/minialpine@" + digest.String())
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "image.tar")
+	require.NoError(t, tarball.MultiRefWriteToFile(path, map[name.Reference]v1.Image{dref: img}))
+
+	u := NewUnpacker()
+	lists, err := u.Extract(t.Context(), &Reference{Archive: path})
+	require.NoError(t, err)
+	require.Len(t, lists, 1)
+
+	roots := lists[0].GetRootNodes()
+	require.Len(t, roots, 1)
+	node := roots[0]
+
+	assert.Equal(t, digest.String(), node.GetName(),
+		"untagged archives identify through the image digest")
+	assert.Empty(t, node.GetVersion())
+	assert.Empty(t, node.GetIdentifiers(), "no reference, no purl")
+	assert.Equal(t, digest.Hex, node.GetHashes()[int32(sbom.HashAlgorithm_SHA256)])
+}
+
+func TestExtractArchiveMultiImage(t *testing.T) {
+	t.Parallel()
+
+	one := buildArchiveImage(t, alpineOSRelease)
+	two := buildArchiveImage(t, "ID=alpine\nVERSION_ID=3.25.0\n")
+	tagOne, err := name.NewTag("registry.example.com/test/one:v1")
+	require.NoError(t, err)
+	tagTwo, err := name.NewTag("registry.example.com/test/two:v1")
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "images.tar")
+	require.NoError(t, tarball.MultiWriteToFile(path, map[name.Tag]v1.Image{
+		tagOne: one,
+		tagTwo: two,
+	}))
+
+	u := NewUnpacker()
+
+	_, err = u.Extract(t.Context(), &Reference{Archive: path})
+	require.ErrorContains(t, err, "set Ref to select one")
+
+	lists, err := u.Extract(t.Context(), &Reference{Ref: tagTwo.String(), Archive: path})
+	require.NoError(t, err)
+	roots := lists[0].GetRootNodes()
+	require.Len(t, roots, 1)
+	assert.Equal(t, tagTwo.String(), roots[0].GetName())
+
+	_, err = u.Extract(t.Context(), &Reference{
+		Ref:     "registry.example.com/test/absent:v1",
+		Archive: path,
+	})
+	require.Error(t, err, "refs not present in the archive fail")
+}

--- a/image/subject.go
+++ b/image/subject.go
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package image implements the unpacker that extracts dependency data from
-// container images. It pulls an image by its OCI reference, squashes its
-// layers into a single filesystem, and routes that filesystem to the
-// SystemPackages unpacker to read the installed-package databases.
+// container images. It pulls an image by its OCI reference, or reads it
+// from a docker-archive tarball, squashes its layers into a single
+// filesystem, and routes that filesystem to the SystemPackages unpacker to
+// read the installed-package databases.
 package image
 
 // SubjectType is the DecomposableSubject type routed to the image unpacker.
@@ -12,10 +13,19 @@ const SubjectType = "image"
 
 // Reference is the DecomposableSubject consumed by the image unpacker: a
 // container image addressed by an OCI reference, e.g. "alpine:3.24",
-// "ghcr.io/org/app@sha256:..." or "registry.example.com/app:v1".
+// "ghcr.io/org/app@sha256:..." or "registry.example.com/app:v1", or held
+// in a docker-archive tarball on disk.
 type Reference struct {
 	// Ref is the OCI reference of the image or image index.
 	Ref string
+
+	// Archive is the path to a docker-archive tarball (the `docker save`
+	// format) holding the image. When set, the image is read from the
+	// archive instead of pulled from a registry. Ref, when also set,
+	// selects the tagged image in a multi-image archive and provides the
+	// reference identity; left empty, the identity comes from the
+	// archive's RepoTags, or from the image digest when it has none.
+	Archive string
 }
 
 // DecomposableType identifies this subject as a container image, routing it

--- a/image/unpacker.go
+++ b/image/unpacker.go
@@ -55,6 +55,13 @@ type Options struct {
 	// package.
 	IncludeFiles bool
 
+	// RecordLayers adds one structural node per image layer, related to
+	// the image through a contains edge. Layers are identified by their
+	// diff id — the digest of the uncompressed layer — and carry no
+	// packages: the package inventory always reads from the squashed
+	// filesystem.
+	RecordLayers bool
+
 	// Hooks receives download progress notifications, e.g. to render a
 	// progress indicator. Optional.
 	Hooks *PullHooks
@@ -277,7 +284,43 @@ func (u *Unpacker) extractImage(ctx context.Context, refStr string, nref name.Re
 			return nil, fmt.Errorf("relating packages to image node: %w", err)
 		}
 	}
+	if u.Options.RecordLayers {
+		if err := recordLayers(nl, node, img); err != nil {
+			return nil, err
+		}
+	}
 	return nl, nil
+}
+
+// recordLayers adds the image's layers to the node list as structural
+// nodes hanging off the image node, in layer order, each carrying its
+// diff id as name and hash.
+func recordLayers(nl *sbom.NodeList, image *sbom.Node, img v1.Image) error {
+	layers, err := img.Layers()
+	if err != nil {
+		return fmt.Errorf("reading image layers: %w", err)
+	}
+	layerList := sbom.NewNodeList()
+	for _, layer := range layers {
+		diffID, err := layer.DiffID()
+		if err != nil {
+			return fmt.Errorf("reading layer diff id: %w", err)
+		}
+		node := &sbom.Node{
+			Id:      uuid.NewString(),
+			Type:    sbom.Node_PACKAGE,
+			Name:    diffID.String(),
+			Comment: "container image layer",
+		}
+		if algo := hashAlgorithm(diffID.Algorithm); algo != sbom.HashAlgorithm_UNKNOWN {
+			node.Hashes = map[int32]string{int32(algo): diffID.Hex}
+		}
+		layerList.AddRootNode(node)
+	}
+	if err := nl.RelateNodeListAtID(layerList, image.GetId(), sbom.Edge_contains); err != nil {
+		return fmt.Errorf("relating layers to image node: %w", err)
+	}
+	return nil
 }
 
 // extractSystemPackages routes the squashed filesystem to the SystemPackages

--- a/image/unpacker.go
+++ b/image/unpacker.go
@@ -75,9 +75,10 @@ type Unpacker struct {
 	Options Options
 }
 
-// Extract pulls the image referenced by the subject and returns its
-// dependency graph: a node describing the image with the system packages
-// found in its filesystem as descendants.
+// Extract pulls the image referenced by the subject — or reads it from
+// the subject's archive — and returns its dependency graph: a node
+// describing the image with the system packages found in its filesystem
+// as descendants.
 func (u *Unpacker) Extract(ctx context.Context, subject api.DecomposableSubject) ([]*sbom.NodeList, error) {
 	if subject == nil {
 		return nil, fmt.Errorf("image unpacker received a nil subject")
@@ -90,6 +91,10 @@ func (u *Unpacker) Extract(ctx context.Context, subject api.DecomposableSubject)
 	}
 	if u.Options.Mode == ModePerLayer {
 		return nil, fmt.Errorf("per-layer extraction is not implemented yet")
+	}
+
+	if ref.Archive != "" {
+		return u.extractArchive(ctx, ref)
 	}
 
 	nref, err := name.ParseReference(ref.Ref)
@@ -298,16 +303,20 @@ func (u *Unpacker) extractSystemPackages(ctx context.Context, fsys fs.FS) ([]*sb
 // as the name, the manifest digest in the hashes, and a pkg:oci purl.
 func imageNode(refStr string, nref name.Reference, digest v1.Hash, arch, osName string) *sbom.Node {
 	node := &sbom.Node{
-		Id:   uuid.NewString(),
-		Type: sbom.Node_PACKAGE,
-		Name: refStr,
-		Identifiers: map[int32]string{
-			int32(sbom.SoftwareIdentifierType_PURL): ociPurl(nref, digest, arch),
-		},
+		Id:             uuid.NewString(),
+		Type:           sbom.Node_PACKAGE,
+		Name:           refStr,
 		PrimaryPurpose: []sbom.Purpose{sbom.Purpose_CONTAINER},
 	}
-	if tag, ok := nref.(name.Tag); ok {
-		node.Version = tag.TagStr()
+	// Untagged archive images have no reference to derive a purl or a
+	// version from; their name is the image digest.
+	if nref != nil {
+		node.Identifiers = map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): ociPurl(nref, digest, arch),
+		}
+		if tag, ok := nref.(name.Tag); ok {
+			node.Version = tag.TagStr()
+		}
 	}
 	if algo := hashAlgorithm(digest.Algorithm); algo != sbom.HashAlgorithm_UNKNOWN {
 		node.Hashes = map[int32]string{int32(algo): digest.Hex}


### PR DESCRIPTION
This pull request adds support for extracting container images from Docker archive tarballs (the `docker save` format) in addition to pulling images from registries. It introduces logic to select images from single- or multi-image archives, adjusts the image identity to handle untagged images, and includes comprehensive tests for these scenarios.

**Support for extracting images from Docker archive tarballs:**

* Added the `Archive` field to the `Reference` struct to specify a Docker archive tarball as the image source, along with documentation on its behavior.
* Modified the `Unpacker.Extract` method to check for the `Archive` field and extract images from tarballs when present. [[1]](diffhunk://#diff-d7eb2ca26bb79a6e684d553586eb7fba650b0b976edd444dbcdbe77734f2d26eL78-R81) [[2]](diffhunk://#diff-d7eb2ca26bb79a6e684d553586eb7fba650b0b976edd444dbcdbe77734f2d26eR96-R99)
* Implemented `extractArchive` and `openArchiveImage` in `archive.go` to handle reading images from tarballs, selecting the correct image in multi-image archives, and determining image identity for untagged images.

**Image node identity and metadata improvements:**

* Updated image node creation to handle untagged archive images by omitting PURL and version when no reference is available, using the image digest as the name.

**Testing:**

* Added `archive_test.go` with tests covering extraction from tagged, untagged, and multi-image archives, ensuring correct identity and error handling.