### PR TITLE
Fix maintainer names and purls

### DIFF
--- a/system/apk/decomposer.go
+++ b/system/apk/decomposer.go
@@ -9,11 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/package-url/packageurl-go"
 	"github.com/protobom/protobom/pkg/sbom"
 
 	api "github.com/carabiner-dev/unpack/api/v1"
@@ -27,6 +27,16 @@ var apkDBLocations = []string{
 	"lib/apk/db/installed",
 	"usr/lib/apk/db/installed", // usr-merged layouts
 }
+
+const (
+	// wolfiNamespace is the os-release ID of Wolfi, the one apk distro whose
+	// package host we can derive download locations from.
+	wolfiNamespace = "wolfi"
+
+	// wolfiPackageHost is the well-known host serving the Wolfi apk
+	// repository. Every Wolfi package is published under it.
+	wolfiPackageHost = "https://packages.wolfi.dev/os"
+)
 
 var _ api.Decomposer = (*Decomposer)(nil)
 
@@ -140,6 +150,9 @@ func packagesToNodeList(pkgs []*apkPackage, osr osrelease.Data, includeFiles boo
 			},
 			PrimaryPurpose: []sbom.Purpose{sbom.Purpose_LIBRARY},
 		}
+		if dl := apkDownloadLocation(p, osr); dl != "" {
+			node.UrlDownload = dl
+		}
 		if p.License != "" {
 			// Alpine's L: field already carries SPDX expressions for the
 			// most part; Normalize fixes stray aliases and leaves
@@ -196,37 +209,49 @@ func addPackageFiles(nl *sbom.NodeList, p *apkPackage, packageID string) error {
 // apk definition: namespace is the lowercased distro id (e.g. "alpine"),
 // and qualifiers include arch, distro (id-version_id), and upstream (the
 // origin/source package when it differs from the package name). Qualifiers
-// are sorted alphabetically and percent-encoded.
+// are sorted alphabetically. Every component is percent-encoded canonically
+// by packageurl-go, so characters the spec reserves — notably '+', which is
+// common in apk package names — come out as %2B and not raw:
 //
-//	pkg:apk/alpine/musl@1.2.4-r2?arch=x86_64&distro=alpine-3.24.0
+//	pkg:apk/alpine/libstdc%2B%2B@14.3.0-r2?arch=x86_64&distro=alpine-3.24.0
 func apkPurl(p *apkPackage, osr osrelease.Data) string {
-	var b strings.Builder
-	b.WriteString("pkg:apk/")
-	if ns := osr.Namespace(); ns != "" {
-		b.WriteString(ns)
-		b.WriteByte('/')
-	}
-	b.WriteString(strings.ToLower(p.Name))
-	if p.Version != "" {
-		b.WriteByte('@')
-		b.WriteString(p.Version)
-	}
-
-	q := url.Values{}
+	q := map[string]string{}
 	if p.Arch != "" {
-		q.Set("arch", strings.ToLower(p.Arch))
+		q["arch"] = strings.ToLower(p.Arch)
 	}
 	if d := osr.Distro(); d != "" {
-		q.Set("distro", d)
+		q["distro"] = d
 	}
 	if p.Origin != "" && p.Origin != p.Name {
-		q.Set("upstream", p.Origin)
+		q["upstream"] = p.Origin
 	}
-	if enc := q.Encode(); enc != "" {
-		b.WriteByte('?')
-		b.WriteString(enc)
+
+	return packageurl.NewPackageURL(
+		packageurl.TypeApk,
+		osr.Namespace(),
+		strings.ToLower(p.Name),
+		p.Version,
+		packageurl.QualifiersFromMap(q),
+		"",
+	).ToString()
+}
+
+// apkDownloadLocation synthesizes the URL a package can be fetched from.
+// Only Wolfi gets one: all of its packages are published under a single
+// well-known host, so the location follows from the installed database
+// alone. Alpine's are spread over user-configured mirrors and per-release
+// repositories that the installed database does not record, so Alpine
+// packages deliberately get no download location rather than a guessed one.
+func apkDownloadLocation(p *apkPackage, osr osrelease.Data) string {
+	if osr.Namespace() != wolfiNamespace {
+		return ""
 	}
-	return b.String()
+	if p.Name == "" || p.Version == "" || p.Arch == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%s/%s/%s-%s.apk", wolfiPackageHost, p.Arch, p.Name, p.Version,
+	)
 }
 
 // getOptions extracts apk-specific options from DecomposerOptions, falling

--- a/system/apk/decomposer_test.go
+++ b/system/apk/decomposer_test.go
@@ -57,6 +57,27 @@ func TestApkPurl(t *testing.T) {
 			osr:  osrelease.Data{},
 			want: "pkg:apk/musl@1.2.6-r2?arch=x86_64",
 		},
+		{
+			name: "no version",
+			pkg: apkPackage{
+				Name: "musl", Arch: "x86_64",
+			},
+			osr:  osrelease.Data{ID: "alpine", VersionID: "3.24.0"},
+			want: "pkg:apk/alpine/musl?arch=x86_64&distro=alpine-3.24.0",
+		},
+		{
+			// '+' is reserved by the purl spec and must be percent-encoded
+			// as %2B in every component, or string-matching consumers
+			// (vulnerability scanners) miss the package.
+			name: "plus signs percent-encoded in name and version",
+			pkg: apkPackage{
+				Name: "libstdc++", Version: "14.3.0+git-r2", Arch: "x86_64",
+				Origin: "gcc+patched",
+			},
+			osr: osrelease.Data{ID: "alpine", VersionID: "3.24.0"},
+			want: "pkg:apk/alpine/libstdc%2B%2B@14.3.0%2Bgit-r2?" +
+				"arch=x86_64&distro=alpine-3.24.0&upstream=gcc%2Bpatched",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -118,6 +139,13 @@ func TestExtractFromFS_Alpine(t *testing.T) {
 		musl.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)],
 	)
 
+	// Alpine mirrors are not derivable from the installed database, so no
+	// download location is synthesized for them.
+	for _, n := range nodes {
+		assert.Empty(t, n.GetUrlDownload(),
+			"alpine packages must not get a guessed download location: %s", n.GetName())
+	}
+
 	// Subpackage: origin differs from name and becomes the upstream
 	// qualifier.
 	binsh := byName["busybox-binsh"]
@@ -158,5 +186,128 @@ func TestExtractFromFS_AlpineIncludeFiles(t *testing.T) {
 	assert.Equal(t,
 		"ef2277245372a40e26c61249af4a2ee82cec2552",
 		loader.GetHashes()[int32(sbom.HashAlgorithm_SHA1)],
+	)
+}
+
+func TestApkDownloadLocation(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		pkg  apkPackage
+		osr  osrelease.Data
+		want string
+	}{
+		{
+			name: "wolfi package gets the well-known host",
+			pkg: apkPackage{
+				Name: "glibc", Version: "2.41-r3", Arch: "x86_64",
+			},
+			osr:  osrelease.Data{ID: "wolfi", VersionID: "20230201"},
+			want: "https://packages.wolfi.dev/os/x86_64/glibc-2.41-r3.apk",
+		},
+		{
+			name: "wolfi id is matched case-insensitively",
+			pkg: apkPackage{
+				Name: "glibc", Version: "2.41-r3", Arch: "aarch64",
+			},
+			osr:  osrelease.Data{ID: "Wolfi", VersionID: "20230201"},
+			want: "https://packages.wolfi.dev/os/aarch64/glibc-2.41-r3.apk",
+		},
+		{
+			name: "alpine gets none: its mirrors are not derivable",
+			pkg: apkPackage{
+				Name: "musl", Version: "1.2.6-r2", Arch: "x86_64",
+			},
+			osr:  osrelease.Data{ID: "alpine", VersionID: "3.24.0"},
+			want: "",
+		},
+		{
+			name: "no os-release: none",
+			pkg: apkPackage{
+				Name: "musl", Version: "1.2.6-r2", Arch: "x86_64",
+			},
+			osr:  osrelease.Data{},
+			want: "",
+		},
+		{
+			name: "wolfi without arch: none",
+			pkg: apkPackage{
+				Name: "glibc", Version: "2.41-r3",
+			},
+			osr:  osrelease.Data{ID: "wolfi", VersionID: "20230201"},
+			want: "",
+		},
+		{
+			name: "wolfi without version: none",
+			pkg: apkPackage{
+				Name: "glibc", Arch: "x86_64",
+			},
+			osr:  osrelease.Data{ID: "wolfi", VersionID: "20230201"},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, apkDownloadLocation(&tc.pkg, tc.osr))
+		})
+	}
+}
+
+// TestExtractFromFS_Wolfi drives the full path over a synthetic Wolfi system
+// root: Wolfi is the only apk distro whose download locations we synthesize.
+func TestExtractFromFS_Wolfi(t *testing.T) {
+	t.Parallel()
+	d := New()
+	nl, err := d.ExtractFromFS(fstest.MapFS{
+		"etc/os-release": &fstest.MapFile{
+			Data: []byte("ID=wolfi\nNAME=\"Wolfi\"\nVERSION_ID=20230201\n"),
+		},
+		"lib/apk/db/installed": &fstest.MapFile{Data: []byte(
+			"C:Q1D1L4TGN2vT+ZBmpKtWDXwLmVGgg=\n" +
+				"P:glibc\n" +
+				"V:2.41-r3\n" +
+				"A:x86_64\n" +
+				"T:the GNU C library\n" +
+				"o:glibc\n" +
+				"\n" +
+				"C:Q1yNZ7cLzTIYSHZ2Wj5vAlZzWuKmA=\n" +
+				"P:libstdc++\n" +
+				"V:14.2.0-r6\n" +
+				"A:x86_64\n" +
+				"o:gcc\n" +
+				"\n",
+		)},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, nl)
+
+	byName := map[string]*sbom.Node{}
+	for _, n := range nl.GetNodes() {
+		byName[n.GetName()] = n
+	}
+	require.Len(t, byName, 2)
+
+	glibc := byName["glibc"]
+	require.NotNil(t, glibc)
+	assert.Equal(t,
+		"pkg:apk/wolfi/glibc@2.41-r3?arch=x86_64&distro=wolfi-20230201",
+		glibc.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)],
+	)
+	assert.Equal(t,
+		"https://packages.wolfi.dev/os/x86_64/glibc-2.41-r3.apk",
+		glibc.GetUrlDownload(),
+	)
+
+	// The '+' in the name is percent-encoded in the purl but stays literal
+	// in the download URL, which is a plain path.
+	stdcpp := byName["libstdc++"]
+	require.NotNil(t, stdcpp)
+	assert.Equal(t,
+		"pkg:apk/wolfi/libstdc%2B%2B@14.2.0-r6?arch=x86_64&distro=wolfi-20230201&upstream=gcc",
+		stdcpp.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)],
+	)
+	assert.Equal(t,
+		"https://packages.wolfi.dev/os/x86_64/libstdc++-14.2.0-r6.apk",
+		stdcpp.GetUrlDownload(),
 	)
 }

--- a/system/deb/decomposer.go
+++ b/system/deb/decomposer.go
@@ -11,12 +11,13 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net/url"
 	"os"
 	"path"
 	"strings"
+	"unicode"
 
 	"github.com/google/uuid"
+	"github.com/package-url/packageurl-go"
 	"github.com/protobom/protobom/pkg/sbom"
 
 	api "github.com/carabiner-dev/unpack/api/v1"
@@ -197,11 +198,16 @@ func packagesToNodeList(source fs.FS, pkgs []*dpkgPackage, osr osrelease.Data, f
 		licenses, concluded := packageLicenses(source, p.Name)
 		node.Licenses = licenses
 		node.LicenseConcluded = concluded
+		if dl := debDownloadLocation(p, osr); dl != "" {
+			node.UrlDownload = dl
+		}
 		if p.Maintainer != "" {
-			// Maintainers are mostly teams (e.g. "Debian GNU Libc
-			// Maintainers"), so flag them as orgs like we do for RPM vendors.
+			// The Maintainer field mixes packaging teams ("Debian OpenSSL
+			// Team") with individual developers ("Santiago Vila") and carries
+			// nothing that tells them apart, so we guess from the name.
 			node.Suppliers = []*sbom.Person{{
-				Name: p.Maintainer, Email: p.Email, IsOrg: true,
+				Name: p.Maintainer, Email: p.Email,
+				IsOrg: maintainerIsOrg(p.Maintainer),
 			}}
 		}
 		nl.AddRootNode(node)
@@ -219,42 +225,148 @@ func packagesToNodeList(source fs.FS, pkgs []*dpkgPackage, osr osrelease.Data, f
 // deb definition: namespace is the lowercased distro id (e.g. "debian"),
 // version is the complete Debian version (the epoch travels inside it), and
 // qualifiers include arch, distro (id-version_id), and upstream (the source
-// package, with its version when the stanza carries one). Qualifiers are
-// sorted alphabetically and percent-encoded.
+// package, with its version when the stanza carries one). packageurl-go
+// sorts the qualifiers alphabetically and applies the canonical
+// percent-encoding, which notably escapes the '+' that Debian versions are
+// full of as %2B.
 //
-//	pkg:deb/debian/curl@7.74.0-1.3+deb11u7?arch=amd64&distro=debian-11
+//	pkg:deb/debian/curl@7.74.0-1.3%2Bdeb11u7?arch=amd64&distro=debian-11
 func debPurl(p *dpkgPackage, osr osrelease.Data) string {
-	var b strings.Builder
-	b.WriteString("pkg:deb/")
-	if ns := osr.Namespace(); ns != "" {
-		b.WriteString(ns)
-		b.WriteByte('/')
-	}
-	b.WriteString(strings.ToLower(p.Name))
-	if p.Version != "" {
-		b.WriteByte('@')
-		b.WriteString(p.Version)
-	}
-
-	q := url.Values{}
+	q := map[string]string{}
 	if p.Architecture != "" {
-		q.Set("arch", strings.ToLower(p.Architecture))
+		q["arch"] = strings.ToLower(p.Architecture)
 	}
 	if d := osr.Distro(); d != "" {
-		q.Set("distro", d)
+		q["distro"] = d
 	}
 	if p.Source != "" {
 		upstream := p.Source
 		if p.SourceVersion != "" {
 			upstream += "@" + p.SourceVersion
 		}
-		q.Set("upstream", upstream)
+		q["upstream"] = upstream
 	}
-	if enc := q.Encode(); enc != "" {
-		b.WriteByte('?')
-		b.WriteString(enc)
+
+	return packageurl.NewPackageURL(
+		packageurl.TypeDebian,
+		osr.Namespace(),
+		strings.ToLower(p.Name),
+		p.Version,
+		packageurl.QualifiersFromMap(q),
+		"",
+	).ToString()
+}
+
+// orgMaintainerWords are the words that mark a Maintainer name as a
+// packaging team rather than a single developer. Both the singular and the
+// plural forms are listed because Debian uses both ("Debian Perl Group",
+// "GNU Libc Maintainers").
+var orgMaintainerWords = map[string]struct{}{
+	"alliance":    {},
+	"alliances":   {},
+	"developer":   {},
+	"developers":  {},
+	"foundation":  {},
+	"foundations": {},
+	"group":       {},
+	"groups":      {},
+	"maintainer":  {},
+	"maintainers": {},
+	"packager":    {},
+	"packagers":   {},
+	"packaging":   {},
+	"project":     {},
+	"projects":    {},
+	"team":        {},
+	"teams":       {},
+}
+
+// maintainerIsOrg guesses whether a Debian Maintainer name denotes an
+// organization (a packaging team) rather than a person. It is a heuristic:
+// the dpkg database records maintainers as free-form RFC822 names with no
+// marker distinguishing "Debian OpenSSL Team" from "Santiago Vila", and SPDX
+// wants us to pick one of Person: or Organization:.
+//
+// The name is split on everything that is not a letter or a digit so that
+// only whole words are considered ("Steam" is not a team, "Grouper" is not a
+// group), and any word in orgMaintainerWords makes it an organization.
+// Anything else is taken to be a person, so unusual team names are reported
+// as people rather than the other way around.
+func maintainerIsOrg(name string) bool {
+	words := strings.FieldsFunc(name, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	for _, w := range words {
+		if _, ok := orgMaintainerWords[strings.ToLower(w)]; ok {
+			return true
+		}
 	}
-	return b.String()
+	return false
+}
+
+const (
+	// debianNamespace is the os-release ID of Debian proper. Only Debian
+	// gets a synthesized download location: derivatives publish elsewhere
+	// (Ubuntu's pool lives on archive.ubuntu.com and is split across
+	// components dpkg never records), so guessing for them yields 404s.
+	debianNamespace = "debian"
+
+	// debianPoolURL is the root of the Debian package pool.
+	debianPoolURL = "http://ftp.debian.org/debian/pool"
+)
+
+// debDownloadLocation synthesizes the URL the binary package can be fetched
+// from in the Debian pool, or "" when we cannot name the file with
+// confidence.
+//
+// The pool is laid out by SOURCE package — pool/main/o/openssl holds every
+// binary built from openssl, libssl3 included — while the .deb file itself
+// is named after the binary package. We assume the "main" component because
+// the dpkg status file does not record which component a package came from,
+// and main is where the overwhelming majority of a Debian system comes from;
+// packages from contrib or non-free get a URL that does not resolve.
+func debDownloadLocation(p *dpkgPackage, osr osrelease.Data) string {
+	if osr.Namespace() != debianNamespace {
+		return ""
+	}
+	if p.Name == "" || p.Version == "" || p.Architecture == "" {
+		return ""
+	}
+
+	// Debian leaves the epoch out of .deb filenames: version "1:2.36-9" is
+	// published as "..._2.36-9_amd64.deb". Drop it, or the URL is wrong for
+	// every package that carries one.
+	version := p.Version
+	if _, rest, found := strings.Cut(version, ":"); found {
+		version = rest
+	}
+	if version == "" {
+		return ""
+	}
+
+	// The Source field is only set when the source package name differs
+	// from the binary one; otherwise they are the same.
+	src := p.Source
+	if src == "" {
+		src = p.Name
+	}
+
+	return fmt.Sprintf(
+		"%s/main/%s/%s/%s_%s_%s.deb",
+		debianPoolURL, debPoolDir(src), src, p.Name, version, p.Architecture,
+	)
+}
+
+// debPoolDir returns the sharding directory a source package sits in inside
+// the pool: the first letter of its name, or the first four characters when
+// it starts with "lib". "lib" is common enough that Debian subdivides it,
+// so glibc lands in pool/main/g/glibc but libzip lands in
+// pool/main/libz/libzip.
+func debPoolDir(source string) string {
+	if len(source) >= 4 && strings.HasPrefix(source, "lib") {
+		return source[:4]
+	}
+	return source[:1]
 }
 
 // getOptions extracts dpkg-specific options from DecomposerOptions, falling

--- a/system/deb/decomposer_test.go
+++ b/system/deb/decomposer_test.go
@@ -28,7 +28,7 @@ func TestDebPurl(t *testing.T) {
 				Name: "curl", Version: "7.74.0-1.3+deb11u7", Architecture: "amd64",
 			},
 			osr:  osrelease.Data{ID: "debian", VersionID: "11"},
-			want: "pkg:deb/debian/curl@7.74.0-1.3+deb11u7?arch=amd64&distro=debian-11",
+			want: "pkg:deb/debian/curl@7.74.0-1.3%2Bdeb11u7?arch=amd64&distro=debian-11",
 		},
 		{
 			name: "epoch travels inside the version",
@@ -45,7 +45,7 @@ func TestDebPurl(t *testing.T) {
 				Source: "glibc",
 			},
 			osr:  osrelease.Data{ID: "debian", VersionID: "11"},
-			want: "pkg:deb/debian/libc6@2.31-13+deb11u6?arch=amd64&distro=debian-11&upstream=glibc",
+			want: "pkg:deb/debian/libc6@2.31-13%2Bdeb11u6?arch=amd64&distro=debian-11&upstream=glibc",
 		},
 		{
 			name: "upstream carries the source version",
@@ -54,7 +54,7 @@ func TestDebPurl(t *testing.T) {
 				Source: "base-files", SourceVersion: "11.1+deb11u6",
 			},
 			osr:  osrelease.Data{ID: "debian", VersionID: "11"},
-			want: "pkg:deb/debian/base-files@11.1+deb11u7?arch=amd64&distro=debian-11&upstream=base-files%4011.1%2Bdeb11u6",
+			want: "pkg:deb/debian/base-files@11.1%2Bdeb11u7?arch=amd64&distro=debian-11&upstream=base-files%4011.1%2Bdeb11u6",
 		},
 		{
 			name: "ubuntu namespace",
@@ -74,6 +74,15 @@ func TestDebPurl(t *testing.T) {
 			want: "pkg:deb/debian/curl@7.74.0-1?arch=arm64&distro=debian-11",
 		},
 		{
+			name: "plus signs in the name are percent-encoded too",
+			pkg: dpkgPackage{
+				Name: "libstdc++6", Version: "12.2.0-14", Architecture: "amd64",
+				Source: "gcc-12",
+			},
+			osr:  osrelease.Data{ID: "debian", VersionID: "12"},
+			want: "pkg:deb/debian/libstdc%2B%2B6@12.2.0-14?arch=amd64&distro=debian-12&upstream=gcc-12",
+		},
+		{
 			name: "no os-release info: namespace and distro omitted",
 			pkg: dpkgPackage{
 				Name: "curl", Version: "7.74.0-1", Architecture: "amd64",
@@ -85,6 +94,150 @@ func TestDebPurl(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.want, debPurl(&tc.pkg, tc.osr))
+		})
+	}
+}
+
+func TestMaintainerIsOrg(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		maintainer string
+		want       bool
+	}{
+		// Real Debian packaging teams.
+		{"Debian OpenSSL Team", true},
+		{"GNU Libc Maintainers", true},
+		{"Mime-Support Packagers", true},
+		{"Debian Perl Group", true},
+		{"Debian Med Packaging Team", true},
+		{"Debian Python Team", true},
+		{"Debian GNOME Maintainers", true},
+		{"Apache Software Foundation", true},
+		{"The Netfilter Project", true},
+		{"Debian systemd Maintainers", true},
+		{"Free Software Alliance", true},
+		{"Debian Kernel Developers", true},
+		// Words are matched even when punctuation glues them to the rest.
+		{"Debian-Kernel-Team", true},
+		{"pkg-mozilla/maintainers", true},
+		// Individual maintainers.
+		{"Santiago Vila", false},
+		{"Marco d'Itri", false},
+		{"Clint Adams", false},
+		{"Guillem Jover", false},
+		{"", false},
+		// Whole words only: no substring false positives.
+		{"Steam Client", false},
+		{"Grouper Tools", false},
+		{"Teamster Jones", false},
+		{"Projectile Motion", false},
+	} {
+		t.Run(tc.maintainer, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, maintainerIsOrg(tc.maintainer))
+		})
+	}
+}
+
+func TestDebDownloadLocation(t *testing.T) {
+	t.Parallel()
+	debian12 := osrelease.Data{ID: "debian", VersionID: "12"}
+	for _, tc := range []struct {
+		name string
+		pkg  dpkgPackage
+		osr  osrelease.Data
+		want string
+	}{
+		{
+			name: "pool directory comes from the source package",
+			pkg: dpkgPackage{
+				Name: "libssl3", Version: "3.0.11-1~deb12u2", Architecture: "amd64",
+				Source: "openssl",
+			},
+			osr:  debian12,
+			want: "http://ftp.debian.org/debian/pool/main/o/openssl/libssl3_3.0.11-1~deb12u2_amd64.deb",
+		},
+		{
+			name: "no Source field: the package is its own source",
+			pkg: dpkgPackage{
+				Name: "base-files", Version: "12.4+deb12u14", Architecture: "amd64",
+			},
+			osr:  debian12,
+			want: "http://ftp.debian.org/debian/pool/main/b/base-files/base-files_12.4+deb12u14_amd64.deb",
+		},
+		{
+			name: "lib sources shard on the first four characters",
+			pkg: dpkgPackage{
+				Name: "libzip4", Version: "1.5.1-4", Architecture: "amd64",
+				Source: "libzip",
+			},
+			osr:  debian12,
+			want: "http://ftp.debian.org/debian/pool/main/libz/libzip/libzip4_1.5.1-4_amd64.deb",
+		},
+		{
+			name: "a lib binary built from a non-lib source shards on the source",
+			pkg: dpkgPackage{
+				Name: "libc6", Version: "2.36-9+deb12u7", Architecture: "amd64",
+				Source: "glibc",
+			},
+			osr:  debian12,
+			want: "http://ftp.debian.org/debian/pool/main/g/glibc/libc6_2.36-9+deb12u7_amd64.deb",
+		},
+		{
+			name: "the epoch is stripped from the filename",
+			pkg: dpkgPackage{
+				Name: "tar", Version: "1:1.34+dfsg-1.2+deb12u1", Architecture: "amd64",
+			},
+			osr:  debian12,
+			want: "http://ftp.debian.org/debian/pool/main/t/tar/tar_1.34+dfsg-1.2+deb12u1_amd64.deb",
+		},
+		{
+			name: "architecture-independent packages keep the all arch",
+			pkg: dpkgPackage{
+				Name: "netbase", Version: "6.4", Architecture: "all",
+			},
+			osr:  debian12,
+			want: "http://ftp.debian.org/debian/pool/main/n/netbase/netbase_6.4_all.deb",
+		},
+		{
+			name: "ubuntu gets no synthesized location",
+			pkg: dpkgPackage{
+				Name: "libssl3", Version: "3.0.2-0ubuntu1.10", Architecture: "amd64",
+				Source: "openssl",
+			},
+			osr:  osrelease.Data{ID: "ubuntu", VersionID: "22.04"},
+			want: "",
+		},
+		{
+			name: "no os-release means no location",
+			pkg: dpkgPackage{
+				Name: "netbase", Version: "6.4", Architecture: "all",
+			},
+			osr:  osrelease.Data{},
+			want: "",
+		},
+		{
+			name: "a missing architecture means no location",
+			pkg:  dpkgPackage{Name: "netbase", Version: "6.4"},
+			osr:  debian12,
+			want: "",
+		},
+		{
+			name: "a missing version means no location",
+			pkg:  dpkgPackage{Name: "netbase", Architecture: "all"},
+			osr:  debian12,
+			want: "",
+		},
+		{
+			name: "a version that is nothing but an epoch means no location",
+			pkg:  dpkgPackage{Name: "netbase", Version: "1:", Architecture: "all"},
+			osr:  debian12,
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, debDownloadLocation(&tc.pkg, tc.osr))
 		})
 	}
 }
@@ -134,14 +287,21 @@ func TestExtractFromFS_StatusFile(t *testing.T) {
 	assert.Equal(t, "GNU C Library: Shared libraries", n.GetSummary())
 	assert.Equal(t, "https://www.gnu.org/software/libc/libc.html", n.GetUrlHome())
 	assert.Equal(t,
-		"pkg:deb/debian/libc6@2.31-13+deb11u6?arch=amd64&distro=debian-11&upstream=glibc",
+		"pkg:deb/debian/libc6@2.31-13%2Bdeb11u6?arch=amd64&distro=debian-11&upstream=glibc",
 		n.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)],
+	)
+
+	// The pool directory comes from the source package (glibc), the filename
+	// from the binary one (libc6).
+	assert.Equal(t,
+		"http://ftp.debian.org/debian/pool/main/g/glibc/libc6_2.31-13+deb11u6_amd64.deb",
+		n.GetUrlDownload(),
 	)
 
 	if assert.Len(t, n.GetSuppliers(), 1) {
 		assert.Equal(t, "GNU Libc Maintainers", n.GetSuppliers()[0].GetName())
 		assert.Equal(t, "debian-glibc@lists.debian.org", n.GetSuppliers()[0].GetEmail())
-		assert.True(t, n.GetSuppliers()[0].GetIsOrg())
+		assert.True(t, n.GetSuppliers()[0].GetIsOrg(), `"Maintainers" marks a team`)
 	}
 }
 
@@ -183,7 +343,7 @@ Description: Basic TCP/IP networking system
 		byName[n.GetName()] = n.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)]
 	}
 	assert.Equal(t,
-		"pkg:deb/debian/base-files@11.1+deb11u7?arch=amd64&distro=debian-11",
+		"pkg:deb/debian/base-files@11.1%2Bdeb11u7?arch=amd64&distro=debian-11",
 		byName["base-files"],
 	)
 	assert.Equal(t,

--- a/system/deb/fixtures_test.go
+++ b/system/deb/fixtures_test.go
@@ -86,12 +86,20 @@ func TestExtractFromFS_DebianSlim(t *testing.T) {
 	if assert.Len(t, libc.GetSuppliers(), 1) {
 		assert.Equal(t, "GNU Libc Maintainers", libc.GetSuppliers()[0].GetName())
 		assert.Equal(t, "debian-glibc@lists.debian.org", libc.GetSuppliers()[0].GetEmail())
+		assert.True(t, libc.GetSuppliers()[0].GetIsOrg(), `"Maintainers" marks a team`)
 	}
 
 	// Namespace and distro come from etc/os-release; upstream from Source.
 	assert.Equal(t,
-		"pkg:deb/debian/libc6@2.41-12+deb13u3?arch=amd64&distro=debian-13&upstream=glibc",
+		"pkg:deb/debian/libc6@2.41-12%2Bdeb13u3?arch=amd64&distro=debian-13&upstream=glibc",
 		libc.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)],
+	)
+
+	// libc6 is built from the glibc source package, so it lives under
+	// pool/main/g/glibc even though the file carries the binary name.
+	assert.Equal(t,
+		"http://ftp.debian.org/debian/pool/main/g/glibc/libc6_2.41-12+deb13u3_amd64.deb",
+		libc.GetUrlDownload(),
 	)
 
 	// Licenses come from the DEP-5 copyright file: the "Files: *" license is
@@ -106,6 +114,16 @@ func TestExtractFromFS_DebianSlim(t *testing.T) {
 	require.NotNil(t, base)
 	assert.Equal(t, "GPL-2.0-or-later", base.GetLicenseConcluded())
 	assert.Equal(t, []string{"GPL-2.0-or-later", "verbatim"}, base.GetLicenses())
+
+	// base-files has no Source field, so it is its own source package.
+	assert.Equal(t,
+		"http://ftp.debian.org/debian/pool/main/b/base-files/base-files_13.8+deb13u5_amd64.deb",
+		base.GetUrlDownload(),
+	)
+	if assert.Len(t, base.GetSuppliers(), 1) {
+		assert.Equal(t, "Santiago Vila", base.GetSuppliers()[0].GetName())
+		assert.False(t, base.GetSuppliers()[0].GetIsOrg(), "a lone developer is a person")
+	}
 }
 
 // TestExtractFromFS_DebianSlimIncludeFiles flips IncludeFiles on and checks
@@ -161,11 +179,11 @@ func TestExtractFromFS_Distroless(t *testing.T) {
 		byName[n.GetName()] = n.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)]
 	}
 	assert.Equal(t,
-		"pkg:deb/debian/base-files@12.4+deb12u14?arch=amd64&distro=debian-12",
+		"pkg:deb/debian/base-files@12.4%2Bdeb12u14?arch=amd64&distro=debian-12",
 		byName["base-files"],
 	)
 	assert.Equal(t,
-		"pkg:deb/debian/tzdata@2026b-0+deb12u1?arch=all&distro=debian-12",
+		"pkg:deb/debian/tzdata@2026b-0%2Bdeb12u1?arch=all&distro=debian-12",
 		byName["tzdata"],
 	)
 	assert.Contains(t, byName, "netbase")
@@ -182,6 +200,31 @@ func TestExtractFromFS_Distroless(t *testing.T) {
 	assert.Equal(t, "GPL-2.0-only", byNodeName["netbase"].GetLicenseConcluded())
 	assert.Empty(t, byNodeName["base-files"].GetLicenses())
 	assert.Empty(t, byNodeName["base-files"].GetLicenseConcluded())
+
+	// None of these stanzas carry a Source field, so each package is its own
+	// source and the pool directory is the first letter of its own name.
+	for name, want := range map[string]string{
+		"base-files":  "http://ftp.debian.org/debian/pool/main/b/base-files/base-files_12.4+deb12u14_amd64.deb",
+		"media-types": "http://ftp.debian.org/debian/pool/main/m/media-types/media-types_10.0.0_all.deb",
+		"netbase":     "http://ftp.debian.org/debian/pool/main/n/netbase/netbase_6.4_all.deb",
+		"tzdata":      "http://ftp.debian.org/debian/pool/main/t/tzdata/tzdata_2026b-0+deb12u1_all.deb",
+	} {
+		assert.Equal(t, want, byNodeName[name].GetUrlDownload(), name)
+	}
+
+	// The four maintainers of this image cover both sides of the person vs
+	// organization heuristic.
+	for name, wantOrg := range map[string]bool{
+		"base-files":  false, // Santiago Vila
+		"netbase":     false, // Marco d'Itri
+		"media-types": true,  // Mime-Support Packagers
+		"tzdata":      true,  // GNU Libc Maintainers
+	} {
+		if assert.Len(t, byNodeName[name].GetSuppliers(), 1, name) {
+			assert.Equal(t, wantOrg, byNodeName[name].GetSuppliers()[0].GetIsOrg(),
+				"%s: %q", name, byNodeName[name].GetSuppliers()[0].GetName())
+		}
+	}
 }
 
 // TestExtractFromFS_DistrolessIncludeFiles checks the distroless file lists

--- a/system/rpm/decomposer.go
+++ b/system/rpm/decomposer.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net/url"
 	"os"
 	"path"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+	"github.com/package-url/packageurl-go"
 	"github.com/protobom/protobom/pkg/sbom"
 
 	api "github.com/carabiner-dev/unpack/api/v1"
@@ -239,44 +239,41 @@ func versionRelease(p *rpmdb.PackageInfo) string {
 // rpm-definition: namespace is the lowercased distro id (e.g. "fedora"),
 // version is the combined version-release, and qualifiers include arch,
 // epoch (when > 0), upstream (the source RPM), distro (id-version_id), and
-// the Fedora modularity label when present. Qualifiers are sorted
-// alphabetically and percent-encoded.
+// the Fedora modularity label when present.
+//
+// Assembly is delegated to packageurl-go so every component carries the
+// canonical purl encoding: qualifiers come out sorted alphabetically and the
+// characters the spec reserves get percent-encoded. That matters for RPM in
+// particular because "+" (which the spec requires to be written "%2B") is
+// common in upstream versions and modular release tags. Scanners match purls
+// by string comparison, so a non-canonical encoding silently misses.
 //
 //	pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25
+//	pkg:rpm/fedora/nodejs@14.21.3-1.module_f38%2B18119%2B78d34c93?arch=x86_64&distro=fedora-38
 func rpmPurl(p *rpmdb.PackageInfo, osr osrelease.Data) string {
-	var b strings.Builder
-	b.WriteString("pkg:rpm/")
-	if ns := osr.Namespace(); ns != "" {
-		b.WriteString(ns)
-		b.WriteByte('/')
-	}
-	b.WriteString(p.Name)
-	if v := versionRelease(p); v != "" {
-		b.WriteByte('@')
-		b.WriteString(v)
-	}
-
-	q := url.Values{}
+	q := map[string]string{}
 	if p.Arch != "" {
-		q.Set("arch", strings.ToLower(p.Arch))
+		q["arch"] = strings.ToLower(p.Arch)
 	}
 	if p.Epoch != nil && *p.Epoch > 0 {
-		q.Set("epoch", strconv.Itoa(*p.Epoch))
+		q["epoch"] = strconv.Itoa(*p.Epoch)
 	}
 	if p.SourceRpm != "" {
-		q.Set("upstream", p.SourceRpm)
+		q["upstream"] = p.SourceRpm
 	}
 	if d := osr.Distro(); d != "" {
-		q.Set("distro", d)
+		q["distro"] = d
 	}
 	if p.Modularitylabel != "" {
-		q.Set("modularitylabel", p.Modularitylabel)
+		q["modularitylabel"] = p.Modularitylabel
 	}
-	if enc := q.Encode(); enc != "" {
-		b.WriteByte('?')
-		b.WriteString(enc)
-	}
-	return b.String()
+
+	// The name is passed through verbatim: RPM package names are
+	// case-sensitive and packageurl-go does not case-fold them.
+	return packageurl.NewPackageURL(
+		packageurl.TypeRPM, osr.Namespace(), p.Name, versionRelease(p),
+		packageurl.QualifiersFromMap(q), "",
+	).ToString()
 }
 
 // getOptions extracts RPM-specific options from DecomposerOptions, falling

--- a/system/rpm/decomposer_test.go
+++ b/system/rpm/decomposer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+	"github.com/package-url/packageurl-go"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,14 +80,48 @@ func TestRpmPurl(t *testing.T) {
 			want: "pkg:rpm/fedora/kernel@6.4.6-200.fc38?arch=x86_64&distro=fedora-38",
 		},
 		{
-			name: "modularitylabel encoded",
+			// "+" in the version has to be written as %2B, while ":" is
+			// allowed unencoded inside a qualifier value.
+			name: "version plus encoded, modularitylabel colons left as-is",
 			pkg: rpmdb.PackageInfo{
 				Name: "nodejs", Version: "14.21.3", Release: "1.module_f38+18119+78d34c93",
 				Arch:            "x86_64",
 				Modularitylabel: "nodejs:14:8060020220421152133:e6e4d6a4",
 			},
 			osr:  osrelease.Data{ID: "fedora", VersionID: "38"},
-			want: "pkg:rpm/fedora/nodejs@14.21.3-1.module_f38+18119+78d34c93?arch=x86_64&distro=fedora-38&modularitylabel=nodejs%3A14%3A8060020220421152133%3Ae6e4d6a4",
+			want: "pkg:rpm/fedora/nodejs@14.21.3-1.module_f38%2B18119%2B78d34c93?arch=x86_64&distro=fedora-38&modularitylabel=nodejs:14:8060020220421152133:e6e4d6a4",
+		},
+		{
+			// RPM names are case-sensitive and may carry underscores; neither
+			// may be folded or escaped away.
+			name: "name case and underscores preserved verbatim",
+			pkg: rpmdb.PackageInfo{
+				Name: "perl-IO_Compress", Version: "2.102", Release: "1.fc38",
+				Arch: "noarch",
+			},
+			osr:  osrelease.Data{ID: "fedora", VersionID: "38"},
+			want: "pkg:rpm/fedora/perl-IO_Compress@2.102-1.fc38?arch=noarch&distro=fedora-38",
+		},
+		{
+			// "+" is not safe in a purl name either.
+			name: "plus in name encoded",
+			pkg: rpmdb.PackageInfo{
+				Name: "libstdc++", Version: "13.2.1", Release: "1.fc38",
+				Arch: "x86_64",
+			},
+			osr:  osrelease.Data{ID: "fedora", VersionID: "38"},
+			want: "pkg:rpm/fedora/libstdc%2B%2B@13.2.1-1.fc38?arch=x86_64&distro=fedora-38",
+		},
+		{
+			// "^" marks a post-release snapshot in RPM versioning and is not
+			// a safe purl character either.
+			name: "caret release marker encoded",
+			pkg: rpmdb.PackageInfo{
+				Name: "golang", Version: "1.22.0", Release: "0.1^20240101gitabc123.fc40",
+				Arch: "x86_64",
+			},
+			osr:  osrelease.Data{ID: "fedora", VersionID: "40"},
+			want: "pkg:rpm/fedora/golang@1.22.0-0.1%5E20240101gitabc123.fc40?arch=x86_64&distro=fedora-40",
 		},
 		{
 			name: "no os-release info: namespace and distro omitted",
@@ -111,6 +146,31 @@ func TestRpmPurl(t *testing.T) {
 			t.Parallel()
 			got := rpmPurl(&tc.pkg, tc.osr)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRpmPurlRoundTrip checks that the percent-encoding rpmPurl emits is
+// lossless: parsing the purl back has to return the exact RPM name and
+// version-release it was built from, including the characters the spec
+// requires to be escaped.
+func TestRpmPurlRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, pkg := range []rpmdb.PackageInfo{
+		{Name: "perl-IO_Compress", Version: "2.102", Release: "1.fc38"},
+		{Name: "libstdc++", Version: "13.2.1", Release: "1.fc38"},
+		{Name: "nodejs", Version: "14.21.3", Release: "1.module_f38+18119+78d34c93"},
+		{Name: "golang", Version: "1.22.0", Release: "0.1^20240101git.fc40"},
+		{Name: "foo", Version: "1.0~rc1", Release: "1.fc38"},
+	} {
+		t.Run(pkg.Name, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := packageurl.FromString(
+				rpmPurl(&pkg, osrelease.Data{ID: "fedora", VersionID: "38"}),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, pkg.Name, parsed.Name)
+			assert.Equal(t, versionRelease(&pkg), parsed.Version)
 		})
 	}
 }


### PR DESCRIPTION
This pull request introduces improvements to how Package URLs (purls) and download locations are generated for APK (Alpine/Wolfi) and DEB (Debian) packages. It ensures proper percent-encoding for special characters in purls, synthesizes download URLs for packages where possible, and enhances the identification of organizational maintainers in Debian packages. The tests are updated and expanded to cover these behaviors.

**Package URL generation and encoding:**

* Switched from manual string construction to using `packageurl-go` for both APK and DEB purl generation, ensuring all components (especially '+') are percent-encoded according to the purl specification. This prevents issues with downstream tools that rely on strict encoding. [[1]](diffhunk://#diff-35bcc43698ea8b668b7f74b3852dcad5e63e12f2505707fee8c4cff3fe463151L199-R254) [[2]](diffhunk://#diff-50f241cca0a928af4766928565c7d90e35ea5f5f7424614806c324a23fc4ca5bL222-R369)
* Updated and added tests to confirm that plus signs and other reserved characters are correctly percent-encoded in the package name and version for both APK and DEB packages. [[1]](diffhunk://#diff-352ed031be96804cc403b2789b49d5c29ee2273d1e0d2786d43987861b5be660R60-R80) [[2]](diffhunk://#diff-9cbe7e00c29ed935e381675e1b9c35e13ad788e3c89479ac75b8e79eb81e6b37L31-R31) [[3]](diffhunk://#diff-9cbe7e00c29ed935e381675e1b9c35e13ad788e3c89479ac75b8e79eb81e6b37L48-R48) [[4]](diffhunk://#diff-9cbe7e00c29ed935e381675e1b9c35e13ad788e3c89479ac75b8e79eb81e6b37L57-R57) [[5]](diffhunk://#diff-9cbe7e00c29ed935e381675e1b9c35e13ad788e3c89479ac75b8e79eb81e6b37R76-R84)

**Download location synthesis:**

* Added logic to synthesize download URLs for Wolfi APK packages and Debian packages (from the official pool), but only when the package metadata and OS-release information make this possible without guessing. Alpine and Debian derivatives do not get guessed URLs. [[1]](diffhunk://#diff-35bcc43698ea8b668b7f74b3852dcad5e63e12f2505707fee8c4cff3fe463151R31-R40) [[2]](diffhunk://#diff-35bcc43698ea8b668b7f74b3852dcad5e63e12f2505707fee8c4cff3fe463151R153-R155) [[3]](diffhunk://#diff-50f241cca0a928af4766928565c7d90e35ea5f5f7424614806c324a23fc4ca5bL222-R369)
* Added comprehensive tests for download location synthesis, ensuring URLs are only set for supported distributions and are omitted otherwise. [[1]](diffhunk://#diff-352ed031be96804cc403b2789b49d5c29ee2273d1e0d2786d43987861b5be660R142-R148) [[2]](diffhunk://#diff-352ed031be96804cc403b2789b49d5c29ee2273d1e0d2786d43987861b5be660R191-R313)

**Debian maintainer organization detection:**

* Improved the heuristic for determining if a Debian package maintainer is an organization or an individual by checking for organization-related keywords in the maintainer's name. [[1]](diffhunk://#diff-50f241cca0a928af4766928565c7d90e35ea5f5f7424614806c324a23fc4ca5bR201-R210) [[2]](diffhunk://#diff-50f241cca0a928af4766928565c7d90e35ea5f5f7424614806c324a23fc4ca5bL222-R369)

These changes improve standards compliance, interoperability, and metadata accuracy for both APK and DEB package analysis.