### PR TITLE
Add SPDX3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Whether you're a developer, security researcher, or compliance officer, Unpack h
 ## Key Features
 
 - **Dependency Extraction**: Analyzes source code to discover dependencies for various languages.
-- **SBOM Parsing**: Reads and understands major SBOM formats like SPDX and CycloneDX.
+- **SBOM Parsing**: Reads and understands major SBOM formats: SPDX 2.2, 2.3 and 3.0.1, and CycloneDX.
 - **Multiple Output Formats**: Displays dependencies as a visual tree or exports to standard SBOM formats.
 - **Extensible Architecture**: Easily extendable to support new languages and package managers.
 - **Attestation Support**: Wraps SBOM outputs in an in-toto attestation for verifiable supply chain security.
@@ -59,14 +59,26 @@ pkg:golang/github.com/carabiner-dev/unpack@v0.1.0-pre3.1+0400cac1
 
 **Example: Generate an SPDX SBOM**
 ```bash
-# Output the dependency graph as an SPDX JSON file
-unpack extract --format=spdx-json /path/to/your/code > my-project.spdx.json
+# Output the dependency graph as an SPDX 2.3 JSON file
+unpack extract --format=spdx /path/to/your/code > my-project.spdx.json
+
+# ...or as SPDX 3.0.1
+unpack extract --format=spdx3 /path/to/your/code > my-project.spdx3.json
 ```
+
+The output formats are:
+
+| `--format` | Writes |
+|---|---|
+| `tree` | an ASCII dependency tree (the default) |
+| `spdx` | SPDX 2.3, JSON |
+| `spdx3` | SPDX 3.0.1, JSON-LD |
+| `cyclonedx`, `cdx` | CycloneDX 1.7, JSON |
 
 **Example: Create a Signed Attestation**
 ```bash
 # Generate an SPDX SBOM and wrap it in a signed in-toto attestation
-unpack extract --attest --format=spdx-json /path/to/your/code
+unpack extract --attest --format=spdx /path/to/your/code
 ```
 
 ### `unpack sbom`: Process Existing SBOMs
@@ -74,11 +86,14 @@ unpack extract --attest --format=spdx-json /path/to/your/code
 Use `sbom` to read, convert, and re-export existing SBOM files.
 
 ```bash
-# Read an SPDX SBOM and display its contents as a tree
-unpack sbom /path/to/sbom.spdx.json
+# Read an SBOM and display its contents as a tree
+unpack sbom -p /path/to/sbom.spdx.json
 
-# Convert an SPDX SBOM to the CycloneDX format
-unpack sbom --format=cyclonedx-json /path/to/sbom.spdx.json
+# Convert an SBOM to CycloneDX
+unpack sbom -p /path/to/sbom.spdx.json --format=cyclonedx
+
+# Convert an SPDX 2.3 SBOM to SPDX 3.0.1
+unpack sbom -p /path/to/sbom.spdx.json --format=spdx3
 ```
 
 ### `unpack ls`: List Discovered Codebases

--- a/README.md
+++ b/README.md
@@ -77,9 +77,17 @@ The output formats are:
 
 **Example: Create a Signed Attestation**
 ```bash
-# Generate an SPDX SBOM and wrap it in a signed in-toto attestation
+# Generate an SBOM and wrap it in a signed in-toto attestation.
+# Attesting without naming a format writes SPDX 3.0.1.
+unpack extract --attest /path/to/your/code
+
+# ...or name the format yourself
 unpack extract --attest --format=spdx /path/to/your/code
 ```
+
+Attestations are made under the predicate type of what they carry:
+`https://spdx.dev/Document/v3` for SPDX 3, `https://spdx.dev/Document` for
+SPDX 2, and `https://cyclonedx.org/bom` for CycloneDX.
 
 ### `unpack sbom`: Process Existing SBOMs
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/knqyf263/go-rpmdb v0.1.1
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 	github.com/package-url/packageurl-go v0.1.6
-	github.com/protobom/protobom v0.5.8
+	github.com/protobom/protobom v0.5.9-0.20260808221622-938f35bcd0da
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -47,6 +47,7 @@ require (
 	github.com/carabiner-dev/osv v0.1.1 // indirect
 	github.com/carabiner-dev/policy v0.5.1 // indirect
 	github.com/carabiner-dev/predicates v0.5.0 // indirect
+	github.com/carabiner-dev/spdx3 v0.1.0 // indirect
 	github.com/carabiner-dev/vcslocator v0.4.6 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/carabiner-dev/protograph v0.0.0-20260117204235-4dc9de9c0db5 h1:afkSTk
 github.com/carabiner-dev/protograph v0.0.0-20260117204235-4dc9de9c0db5/go.mod h1:oP90agfO9tjU30S5N9gDSIgmUg5x94C1uCjeugjJtn4=
 github.com/carabiner-dev/signer v0.5.3-0.20260728042848-608f5e258e3a h1:7q9CaMyYk8X2noWY7wgysu3aeVEdFN0a5CnY1GR4/gs=
 github.com/carabiner-dev/signer v0.5.3-0.20260728042848-608f5e258e3a/go.mod h1:Dyy5pd6seCI6ao/IP/qy8hywnrOLcfjOmT64vlwJ5zI=
+github.com/carabiner-dev/spdx3 v0.1.0 h1:Q6nMLXV0BhtqDQuwRDOaJDZR670TK4jdOvZqvTW/ctY=
+github.com/carabiner-dev/spdx3 v0.1.0/go.mod h1:d/t010TrZvYZBeYGpvHeId6QpRvGLlqK7cy0E81npPA=
 github.com/carabiner-dev/termtable v1.1.0 h1:b/7IqM52Wqwi9njjnAEIDddUYyX23msFkQVihkwarDs=
 github.com/carabiner-dev/termtable v1.1.0/go.mod h1:f2kBeZo0N9vQEMhfDfxv+DdXXy7eb9Wvu9u1sSyvR2A=
 github.com/carabiner-dev/vcslocator v0.4.6 h1:cwoJze9lQC4FDpxNryx4qmBE6pFQiv5JLDjLjIPFZX8=
@@ -374,8 +376,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/protobom/protobom v0.5.8 h1:RNvNF0Wltj29izbx4HPtdRabRQcBPhLfZzYrzdNjFFU=
-github.com/protobom/protobom v0.5.8/go.mod h1:0qUbAUOKKg/m1RLibtom+IFXkiBz/x1MqxpWbDL3lQw=
+github.com/protobom/protobom v0.5.9-0.20260808221622-938f35bcd0da h1:Ss61wo8otclSDwKfL4OhW31AdgBN7WBlabSZdyskIoM=
+github.com/protobom/protobom v0.5.9-0.20260808221622-938f35bcd0da/go.mod h1:WjMp+9dR4qjGqJBqUdTAWsIT5MSyO6Y4XuoEEip7Fqo=
 github.com/remyoudompheng/bigfft v0.0.0-20230126093431-47fa9a501578 h1:VstopitMQi3hZP0fzvnsLmzXZdQGc4bEcgu24cp+d4M=
 github.com/remyoudompheng/bigfft v0.0.0-20230126093431-47fa9a501578/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/cmd/extract.go
+++ b/internal/cmd/extract.go
@@ -23,10 +23,15 @@ import (
 )
 
 const (
-	formatSPDX = "spdx"
-	formatCDX  = "cyclonedx"
-	formatCDXS = "cdx"
-	formatTree = "tree"
+	// The SBOM formats the output can be written in. A bare name selects
+	// the version of that standard unpack writes by default; SPDX 3 is a
+	// name of its own so that a caller asking for "spdx" keeps getting the
+	// SPDX 2.3 it has always got.
+	formatSPDX  = "spdx"
+	formatSPDX3 = "spdx3"
+	formatCDX   = "cyclonedx"
+	formatCDXS  = "cdx"
+	formatTree  = "tree"
 )
 
 type extractOptions struct {
@@ -45,7 +50,11 @@ type extractOptions struct {
 	OutputPrefix         string
 }
 
-var validFormats = []string{formatSPDX, formatCDX, formatCDXS, formatTree}
+var validFormats = []string{formatSPDX, formatSPDX3, formatCDX, formatCDXS, formatTree}
+
+// sbomFormats are the formats that produce a document, as opposed to the
+// tree view. Only these can be attested.
+var sbomFormats = []string{formatSPDX, formatSPDX3, formatCDX, formatCDXS}
 
 // Validates the options in context with arguments
 func (ro *extractOptions) Validate() error {

--- a/internal/cmd/image_test.go
+++ b/internal/cmd/image_test.go
@@ -37,9 +37,11 @@ func TestFormatOptionsValidate(t *testing.T) {
 	}{
 		{"default tree", formatOptions{Format: formatTree}, ""},
 		{"spdx", formatOptions{Format: formatSPDX}, ""},
+		{"spdx3", formatOptions{Format: formatSPDX3}, ""},
 		{"bogus format", formatOptions{Format: "yaml"}, "invalid format"},
 		{"attest needs sbom format", formatOptions{Format: formatTree, Attest: true}, "attestations can only"},
 		{"attest with cdx", formatOptions{Format: formatCDXS, Attest: true}, ""},
+		{"attest with spdx3", formatOptions{Format: formatSPDX3, Attest: true}, ""},
 		{"sign implies attest", formatOptions{Format: formatSPDX, Sign: true}, ""},
 		{"sign with tree fails", formatOptions{Format: formatTree, Sign: true}, "attestations can only"},
 	} {

--- a/internal/cmd/image_test.go
+++ b/internal/cmd/image_test.go
@@ -72,7 +72,7 @@ func TestFormatOptionsDefaultToSPDX(t *testing.T) {
 
 	require.NoError(t, cmd.PersistentFlags().Set("attest", "true"))
 	opts.DefaultToSPDX(cmd)
-	assert.Equal(t, formatSPDX, opts.Format)
+	assert.Equal(t, formatSPDX3, opts.Format)
 
 	// An explicit format is respected.
 	opts2 := &formatOptions{}
@@ -82,6 +82,15 @@ func TestFormatOptionsDefaultToSPDX(t *testing.T) {
 	require.NoError(t, cmd2.PersistentFlags().Set("attest", "true"))
 	opts2.DefaultToSPDX(cmd2)
 	assert.Equal(t, formatCDXS, opts2.Format)
+
+	// Including an explicit SPDX 2.3, which must not be quietly upgraded.
+	opts3 := &formatOptions{}
+	cmd3 := &cobra.Command{}
+	opts3.AddFlags(cmd3)
+	require.NoError(t, cmd3.PersistentFlags().Set("format", formatSPDX))
+	require.NoError(t, cmd3.PersistentFlags().Set("attest", "true"))
+	opts3.DefaultToSPDX(cmd3)
+	assert.Equal(t, formatSPDX, opts3.Format)
 }
 
 // imageTestDB is a one-package apk database for the CLI round-trip.

--- a/internal/cmd/optionsets.go
+++ b/internal/cmd/optionsets.go
@@ -43,7 +43,7 @@ func (fo *formatOptions) Config() *command.OptionsSetConfig {
 				},
 				"attest": {
 					Long: "attest",
-					Help: "output sboms in an intoto attestation (defaults to format=spdx)",
+					Help: "output sboms in an intoto attestation (defaults to format=spdx3)",
 				},
 				"sign": {
 					Long: "sign",
@@ -91,11 +91,15 @@ func (fo *formatOptions) Validate() error {
 // DefaultToSPDX switches the format to SPDX when attesting or signing was
 // requested but no explicit format was chosen. Call it from PreRun, where
 // the flag change state is known.
+//
+// The SPDX it picks is 3.0.1. Asking for "spdx" still writes 2.3, for
+// everyone who has that in a script; it is only the choice made on the
+// caller's behalf that moves.
 func (fo *formatOptions) DefaultToSPDX(cmd *cobra.Command) {
 	flag := fo.Config().LongFlag("format")
 	if (fo.Attest || fo.Sign) &&
 		!cmd.Flags().Changed(flag) && !cmd.PersistentFlags().Changed(flag) {
-		fo.Format = formatSPDX
+		fo.Format = formatSPDX3
 	}
 }
 

--- a/internal/cmd/optionsets.go
+++ b/internal/cmd/optionsets.go
@@ -82,7 +82,7 @@ func (fo *formatOptions) Validate() error {
 		fo.Attest = true
 	}
 
-	if fo.Attest && (fo.Format != formatSPDX && fo.Format != formatCDX && fo.Format != formatCDXS) {
+	if fo.Attest && !slices.Contains(sbomFormats, fo.Format) {
 		errs = append(errs, errors.New("attestations can only be generated when output set to SPDX or CycloneDX"))
 	}
 	return errors.Join(errs...)
@@ -106,8 +106,10 @@ func (fo *formatOptions) ProtobomFormat() (formats.Format, bool) {
 	switch fo.Format {
 	case formatSPDX:
 		return formats.SPDX23JSON, true
+	case formatSPDX3:
+		return formats.SPDX3JSON, true
 	case formatCDX, formatCDXS:
-		return formats.CDX16JSON, true
+		return formats.CDX17JSON, true
 	default:
 		return "", false
 	}

--- a/internal/cmd/optionsets_test.go
+++ b/internal/cmd/optionsets_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProtobomFormat pins which document each format value writes. A bare
+// standard name selects the version unpack writes by default, and moving one
+// of those changes what everybody's scripts produce, so it should be a test
+// failure rather than a surprise.
+func TestProtobomFormat(t *testing.T) {
+	t.Parallel()
+
+	for name, expected := range map[string]formats.Format{
+		formatSPDX:  formats.SPDX23JSON,
+		formatSPDX3: formats.SPDX3JSON,
+		formatCDX:   formats.CDX17JSON,
+		formatCDXS:  formats.CDX17JSON,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			format, ok := (&formatOptions{Format: name}).ProtobomFormat()
+			require.True(t, ok, "%s should be an SBOM format", name)
+			require.Equal(t, expected, format)
+		})
+	}
+
+	// The tree is a view, not a document: it has no protobom format.
+	t.Run(formatTree, func(t *testing.T) {
+		t.Parallel()
+		_, ok := (&formatOptions{Format: formatTree}).ProtobomFormat()
+		require.False(t, ok)
+	})
+
+	// Every format that can be written has to be one protobom can write.
+	t.Run("every sbom format resolves", func(t *testing.T) {
+		t.Parallel()
+		for _, name := range sbomFormats {
+			format, ok := (&formatOptions{Format: name}).ProtobomFormat()
+			require.True(t, ok, "%s is listed as an SBOM format but resolves to nothing", name)
+			require.Contains(t, formats.List, format, "protobom does not know %s", format)
+		}
+	})
+}
+
+// TestPredicateTypeFor pins the in-toto predicate type each format is
+// attested under. SPDX 3 has one of its own: it is a different serialization
+// of a different model, so a consumer must be able to tell from the
+// statement whether it can read the predicate.
+func TestPredicateTypeFor(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		format   formats.Format
+		expected string
+	}{
+		"spdx 3.0.1":    {formats.SPDX3JSON, "https://spdx.dev/Document/v3"},
+		"spdx 2.3":      {formats.SPDX23JSON, "https://spdx.dev/Document"},
+		"spdx 2.2":      {formats.SPDX22JSON, "https://spdx.dev/Document"},
+		"spdx 2.3 tag":  {formats.SPDX23TV, "https://spdx.dev/Document"},
+		"cyclonedx 1.7": {formats.CDX17JSON, "https://cyclonedx.org/bom"},
+		"cyclonedx 1.4": {formats.CDX14JSON, "https://cyclonedx.org/bom"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			predicateType, err := predicateTypeFor(tc.format)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, predicateType)
+		})
+	}
+
+	// A format that is not an SBOM has nothing to be attested as.
+	t.Run("not a format at all", func(t *testing.T) {
+		t.Parallel()
+		_, err := predicateTypeFor(formats.EmptyFormat)
+		require.Error(t, err)
+	})
+
+	// Everything the CLI can write can be attested.
+	t.Run("every sbom format has a predicate type", func(t *testing.T) {
+		t.Parallel()
+		for _, name := range sbomFormats {
+			format, ok := (&formatOptions{Format: name}).ProtobomFormat()
+			require.True(t, ok)
+			_, err := predicateTypeFor(format)
+			require.NoError(t, err, "%s cannot be attested", name)
+		}
+	})
+}

--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -35,16 +35,31 @@ func (bc *bcloser) Write(d []byte) (int, error) {
 	return bc.Buffer.Write(d)
 }
 
+// predicateTypeFor returns the in-toto predicate type naming what a document
+// in this format is.
+//
+// SPDX 3 has one of its own. It is a different serialization of a different
+// model, not a new version of the same document, so a consumer has to be able
+// to tell from the statement whether it can read the predicate without first
+// parsing it.
+func predicateTypeFor(format formats.Format) (string, error) {
+	switch {
+	case format == formats.SPDX3JSON:
+		return "https://spdx.dev/Document/v3", nil
+	case format.Type() == formats.SPDXFORMAT:
+		return "https://spdx.dev/Document", nil
+	case format.Type() == formats.CDXFORMAT:
+		return "https://cyclonedx.org/bom", nil
+	default:
+		return "", fmt.Errorf("unsupported format to attest: %s", format)
+	}
+}
+
 // nodeLlistToAttestation writes the nodelist to an attestation
 func nodeListToAttestation(wr io.WriteCloser, format formats.Format, nl *sbom.NodeList) error {
-	var predicateType string
-	switch format.Type() {
-	case formatSPDX:
-		predicateType = "https://spdx.dev/Document"
-	case formatCDX:
-		predicateType = "https://cyclonedx.org/bom"
-	default:
-		return fmt.Errorf("unsupported format to attest")
+	predicateType, err := predicateTypeFor(format)
+	if err != nil {
+		return err
 	}
 
 	// Create the new attestation

--- a/internal/cmd/sbom.go
+++ b/internal/cmd/sbom.go
@@ -43,7 +43,7 @@ func (ro *sbomOptions) Validate() error {
 		ro.Attest = true
 	}
 
-	if ro.Attest && (ro.Format != formatSPDX && ro.Format != formatCDX) {
+	if ro.Attest && !slices.Contains(sbomFormats, ro.Format) {
 		errs = append(errs, fmt.Errorf("attestations can only be generated when output set to SPDX or CycloneDX"))
 	}
 
@@ -130,8 +130,10 @@ Unpack sbom takes an SBOM document and returns dependency data from its contents
 				return nil
 			case formatSPDX:
 				format = formats.SPDX23JSON
+			case formatSPDX3:
+				format = formats.SPDX3JSON
 			case formatCDXS, formatCDX:
-				format = formats.CDX16JSON
+				format = formats.CDX17JSON
 			default:
 				return fmt.Errorf("invalid format")
 			}


### PR DESCRIPTION
Now that protobom supports SPDX3, we add SPDX3 support to unpack, making it the default for attestations.