### PR TITLE
Add pnpm-lock.yaml to the JavaScript decomposer

### DIFF
--- a/source/npm/decomposer.go
+++ b/source/npm/decomposer.go
@@ -5,7 +5,9 @@ package npm
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/protobom/protobom/pkg/sbom"
@@ -62,6 +64,20 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 		workDir = "."
 	}
 
+	// A codebase holding several lockfiles is read from npm's own first:
+	// package-lock.json is the format this decomposer grew up on.
+	switch {
+	case fileExists(filepath.Join(workDir, "package-lock.json")):
+		return d.extractNpm(workDir, opts)
+	case fileExists(filepath.Join(workDir, "pnpm-lock.yaml")):
+		return d.extractPnpm(workDir, opts)
+	default:
+		return nil, fmt.Errorf("no supported JavaScript lockfile in %s", workDir)
+	}
+}
+
+// extractNpm builds the graph from package-lock.json.
+func (d *Decomposer) extractNpm(workDir string, opts *api.DecomposerOptions) (*sbom.NodeList, error) {
 	// Parse package.json
 	packageJSON, err := ParsePackageJSON(workDir)
 	if err != nil {
@@ -86,19 +102,51 @@ func (d *Decomposer) Extract(opts *api.DecomposerOptions) (*sbom.NodeList, error
 	return nl, nil
 }
 
-// FindCodeBases locates npm codebases by looking for package-lock.json files.
-func (d *Decomposer) FindCodeBases(index *code.PathIndex) ([]string, error) {
-	// FInd the node codebases from the indexer
-	allCodebases, err := index.FindFileLocations("package-lock.json")
+// extractPnpm builds the graph from pnpm-lock.yaml.
+func (d *Decomposer) extractPnpm(workDir string, opts *api.DecomposerOptions) (*sbom.NodeList, error) {
+	lock, err := ReadPnpmLock(workDir)
 	if err != nil {
 		return nil, err
 	}
-	filteredCodebases := []string{}
-	for _, c := range allCodebases {
-		if strings.Contains(c, string(filepath.Separator)+"%snode_modules%s"+string(filepath.Separator)) {
-			continue
+	return buildPnpmTree(lock, workDir, opts)
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// FindCodeBases locates JavaScript codebases by their lockfiles. Lockfiles
+// vendored under node_modules belong to installed dependencies, not to the
+// codebase, and are skipped.
+func (d *Decomposer) FindCodeBases(index *code.PathIndex) ([]string, error) {
+	locations := map[string]bool{}
+	for _, lockfile := range []string{"package-lock.json", "pnpm-lock.yaml"} {
+		found, err := index.FindFileLocations(lockfile)
+		if err != nil {
+			return nil, err
 		}
-		filteredCodebases = append(filteredCodebases, c)
+		for _, dir := range found {
+			if insideNodeModules(dir) {
+				continue
+			}
+			locations[dir] = true
+		}
 	}
-	return filteredCodebases, nil
+	dirs := make([]string, 0, len(locations))
+	for dir := range locations {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}
+
+// insideNodeModules says whether a path has a node_modules segment.
+func insideNodeModules(dir string) bool {
+	for _, segment := range strings.Split(filepath.ToSlash(dir), "/") {
+		if segment == "node_modules" {
+			return true
+		}
+	}
+	return false
 }

--- a/source/npm/pnpm_test.go
+++ b/source/npm/pnpm_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package npm
+
+import (
+	"testing"
+
+	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/carabiner-dev/unpack/api/v1"
+	"github.com/carabiner-dev/unpack/code"
+)
+
+// extractPnpm runs the decomposer over a pnpm testdata codebase.
+func extractPnpmTree(t *testing.T, testdata string, opts *api.DecomposerOptions) *sbom.NodeList {
+	t.Helper()
+	if opts == nil {
+		opts = &api.DecomposerOptions{}
+	}
+	opts.WorkDir = "testdata/" + testdata
+	nl, err := New().Extract(opts)
+	require.NoError(t, err)
+	return nl
+}
+
+func pnpmNodeNamed(t *testing.T, nl *sbom.NodeList, name string) *sbom.Node {
+	t.Helper()
+	var found *sbom.Node
+	for _, n := range nl.GetNodes() {
+		if n.GetName() == name {
+			require.Nil(t, found, "more than one node named %s", name)
+			found = n
+		}
+	}
+	require.NotNil(t, found, "no node named %s", name)
+	return found
+}
+
+func pnpmHasEdge(nl *sbom.NodeList, edgeType sbom.Edge_Type, from, to *sbom.Node) bool {
+	for _, e := range nl.GetEdges() {
+		if e.GetType() == edgeType && e.GetFrom() == from.GetId() {
+			for _, id := range e.GetTo() {
+				if id == to.GetId() {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// TestExtractPnpm reads the lock pnpm 11 writes (schema 9) and
+// TestExtractPnpm6 the one pnpm 8 writes (schema 6): the same project,
+// the same expectations, two spellings.
+func TestExtractPnpm(t *testing.T) {
+	t.Parallel()
+	for name, testdata := range map[string]string{
+		"schema 9": "pnpm",
+		"schema 6": "pnpm6",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nl := extractPnpmTree(t, testdata, nil)
+
+			// The project roots the graph with its manifest's identity.
+			root := pnpmNodeNamed(t, nl, "jsdemo")
+			require.Equal(t, []string{root.GetId()}, nl.GetRootElements())
+			require.Equal(t, "0.1.0", root.GetVersion())
+
+			// Runtime dependencies and their edges: debug pulls in ms.
+			debug := pnpmNodeNamed(t, nl, "debug")
+			ms := pnpmNodeNamed(t, nl, "ms")
+			require.True(t, pnpmHasEdge(nl, sbom.Edge_dependsOn, root, debug))
+			require.True(t, pnpmHasEdge(nl, sbom.Edge_dependsOn, root, ms))
+			require.True(t, pnpmHasEdge(nl, sbom.Edge_dependsOn, debug, ms))
+
+			// Neither the dev nor the optional sections were asked for.
+			for _, n := range nl.GetNodes() {
+				require.NotEqual(t, "once", n.GetName())
+				require.NotEqual(t, "wrappy", n.GetName())
+			}
+
+			// The lock's SRI integrity becomes the node's hash, in hex.
+			hash := debug.GetHashes()[int32(sbom.HashAlgorithm_SHA512)]
+			require.Len(t, hash, 128)
+			require.Equal(t, "pkg:npm/debug@"+debug.GetVersion(),
+				debug.GetIdentifiers()[int32(sbom.SoftwareIdentifierType_PURL)])
+		})
+	}
+}
+
+func TestExtractPnpmDevAndOptional(t *testing.T) {
+	t.Parallel()
+
+	opts := &api.DecomposerOptions{IncludeDev: true, IncludeOptional: true}
+	nl := extractPnpmTree(t, "pnpm", opts)
+
+	root := pnpmNodeNamed(t, nl, "jsdemo")
+	once := pnpmNodeNamed(t, nl, "once")
+	wrappy := pnpmNodeNamed(t, nl, "wrappy")
+
+	require.True(t, pnpmHasEdge(nl, sbom.Edge_devDependency, root, once))
+	require.True(t, pnpmHasEdge(nl, sbom.Edge_optionalDependency, root, wrappy))
+
+	// The dev dependency's own runtime needs came with it, as plain
+	// dependencies of it.
+	require.True(t, pnpmHasEdge(nl, sbom.Edge_dependsOn, once, wrappy))
+}
+
+// TestExtractPnpmWorkspace reads a workspace lock: every importer roots
+// the graph, and a workspace:* dependency is an edge between importers.
+func TestExtractPnpmWorkspace(t *testing.T) {
+	t.Parallel()
+
+	opts := &api.DecomposerOptions{IncludeDev: true}
+	nl := extractPnpmTree(t, "pnpmws", opts)
+
+	require.Len(t, nl.GetRootElements(), 2)
+	root := pnpmNodeNamed(t, nl, "jsws")
+	liba := pnpmNodeNamed(t, nl, "liba")
+	require.Contains(t, nl.GetRootElements(), root.GetId())
+	require.Contains(t, nl.GetRootElements(), liba.GetId())
+
+	// The member keeps its own manifest's identity,
+	require.Equal(t, "0.2.0", liba.GetVersion())
+
+	// the link: dependency is an edge from the project to the member,
+	require.True(t, pnpmHasEdge(nl, sbom.Edge_dependsOn, root, liba))
+
+	// and the member's own dependencies hang under it.
+	require.True(t, pnpmHasEdge(nl, sbom.Edge_dependsOn, liba, pnpmNodeNamed(t, nl, "wrappy")))
+}
+
+// TestFindCodeBasesLockfiles pins the discovery rules: both lockfiles are
+// codebases, and anything under node_modules is not. The node_modules
+// filter used to compare against a literal "%snode_modules%s", so it never
+// filtered anything.
+func TestFindCodeBasesLockfiles(t *testing.T) {
+	t.Parallel()
+
+	index := code.PathIndex{}
+	index.Add("app", "package-lock.json")
+	index.Add("tool", "pnpm-lock.yaml")
+	index.Add("app/node_modules/dep", "package-lock.json")
+	index.Add("app/node_modules/other", "pnpm-lock.yaml")
+
+	locations, err := New().FindCodeBases(&index)
+	require.NoError(t, err)
+	require.Equal(t, []string{"app", "tool"}, locations)
+}

--- a/source/npm/pnpmlock.go
+++ b/source/npm/pnpmlock.go
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package npm
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This file reads pnpm-lock.yaml, in the two schema generations still in
+// the wild: 6 (pnpm 8) and 9 (pnpm 9 onward). The differences are spelling,
+// not substance — 6 prefixes package keys with a slash and keeps edges on
+// the package entries, 9 moves the edges to a snapshots table and, for a
+// single project, 6 states the direct dependencies at the top level where 9
+// always writes an importers table — so the parser normalizes both into one
+// shape and the graph builder never knows which it read.
+
+// PnpmLock is a parsed pnpm-lock.yaml, normalized.
+type PnpmLock struct {
+	// LockfileVersion is the schema version the file declared.
+	LockfileVersion string
+
+	// Importers are the project's own packages: "." for the project
+	// itself, one more per workspace member, keyed by their directory.
+	Importers map[string]*PnpmImporter
+
+	// Packages are the resolved third-party packages, keyed name@version.
+	Packages map[string]*PnpmPackage
+}
+
+// PnpmImporter is one of the project's own packages, with its direct
+// dependencies by kind. Values are version references: a resolved version,
+// or link:<path> pointing at another importer.
+type PnpmImporter struct {
+	Dependencies         map[string]string
+	DevDependencies      map[string]string
+	OptionalDependencies map[string]string
+}
+
+// PnpmPackage is one resolved package.
+type PnpmPackage struct {
+	Name      string
+	Version   string
+	Integrity string
+	Tarball   string
+
+	// Dependencies and OptionalDependencies are the package's edges,
+	// name to resolved version.
+	Dependencies         map[string]string
+	OptionalDependencies map[string]string
+}
+
+// rawPnpmLock is the file as YAML sees it, both generations at once.
+type rawPnpmLock struct {
+	LockfileVersion string                     `yaml:"lockfileVersion"`
+	Importers       map[string]rawPnpmImporter `yaml:"importers"`
+
+	// The flat form a version 6 single-project lock uses.
+	Dependencies         map[string]rawPnpmImporterDep `yaml:"dependencies"`
+	DevDependencies      map[string]rawPnpmImporterDep `yaml:"devDependencies"`
+	OptionalDependencies map[string]rawPnpmImporterDep `yaml:"optionalDependencies"`
+
+	Packages  map[string]rawPnpmPackage  `yaml:"packages"`
+	Snapshots map[string]rawPnpmSnapshot `yaml:"snapshots"`
+}
+
+type rawPnpmImporter struct {
+	Dependencies         map[string]rawPnpmImporterDep `yaml:"dependencies"`
+	DevDependencies      map[string]rawPnpmImporterDep `yaml:"devDependencies"`
+	OptionalDependencies map[string]rawPnpmImporterDep `yaml:"optionalDependencies"`
+}
+
+type rawPnpmImporterDep struct {
+	Version string `yaml:"version"`
+}
+
+type rawPnpmPackage struct {
+	Resolution struct {
+		Integrity string `yaml:"integrity"`
+		Tarball   string `yaml:"tarball"`
+	} `yaml:"resolution"`
+	Dependencies         map[string]string `yaml:"dependencies"`
+	OptionalDependencies map[string]string `yaml:"optionalDependencies"`
+}
+
+type rawPnpmSnapshot struct {
+	Dependencies         map[string]string `yaml:"dependencies"`
+	OptionalDependencies map[string]string `yaml:"optionalDependencies"`
+}
+
+// ParsePnpmLock reads a pnpm-lock.yaml document.
+func ParsePnpmLock(data []byte) (*PnpmLock, error) {
+	raw := &rawPnpmLock{}
+	if err := yaml.Unmarshal(data, raw); err != nil {
+		return nil, fmt.Errorf("parsing pnpm-lock.yaml: %w", err)
+	}
+
+	major, _, _ := strings.Cut(raw.LockfileVersion, ".")
+	if major != "6" && major != "9" {
+		return nil, fmt.Errorf(
+			"pnpm-lock.yaml is schema version %q, this reader understands 6 and 9",
+			raw.LockfileVersion,
+		)
+	}
+
+	lock := &PnpmLock{
+		LockfileVersion: raw.LockfileVersion,
+		Importers:       map[string]*PnpmImporter{},
+		Packages:        map[string]*PnpmPackage{},
+	}
+
+	for dir, importer := range raw.Importers {
+		lock.Importers[dir] = &PnpmImporter{
+			Dependencies:         importerDeps(importer.Dependencies),
+			DevDependencies:      importerDeps(importer.DevDependencies),
+			OptionalDependencies: importerDeps(importer.OptionalDependencies),
+		}
+	}
+	// A version 6 single-project lock has no importers table: its top
+	// level is the one importer.
+	if len(lock.Importers) == 0 {
+		lock.Importers["."] = &PnpmImporter{
+			Dependencies:         importerDeps(raw.Dependencies),
+			DevDependencies:      importerDeps(raw.DevDependencies),
+			OptionalDependencies: importerDeps(raw.OptionalDependencies),
+		}
+	}
+
+	for key, entry := range raw.Packages {
+		name, version, err := pnpmKeyParts(key)
+		if err != nil {
+			return nil, err
+		}
+		pkg := &PnpmPackage{
+			Name:                 name,
+			Version:              version,
+			Integrity:            entry.Resolution.Integrity,
+			Tarball:              entry.Resolution.Tarball,
+			Dependencies:         pnpmVersionRefs(entry.Dependencies),
+			OptionalDependencies: pnpmVersionRefs(entry.OptionalDependencies),
+		}
+		lock.Packages[name+"@"+version] = pkg
+	}
+
+	// Version 9 keeps the edges in snapshots; fold them onto the packages.
+	for key, snapshot := range raw.Snapshots {
+		name, version, err := pnpmKeyParts(key)
+		if err != nil {
+			return nil, err
+		}
+		pkg, ok := lock.Packages[name+"@"+version]
+		if !ok {
+			continue
+		}
+		pkg.Dependencies = pnpmVersionRefs(snapshot.Dependencies)
+		pkg.OptionalDependencies = pnpmVersionRefs(snapshot.OptionalDependencies)
+	}
+
+	return lock, nil
+}
+
+// ReadPnpmLock reads a pnpm-lock.yaml from a directory.
+func ReadPnpmLock(workDir string) (*PnpmLock, error) {
+	data, err := os.ReadFile(filepath.Join(workDir, "pnpm-lock.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("reading lockfile: %w", err)
+	}
+	return ParsePnpmLock(data)
+}
+
+// pnpmKeyParts splits a package key into name and version. Version 6 keys
+// carry a leading slash, either generation may carry a parenthesized peer
+// suffix, and a scoped name holds an @ of its own, so the version starts at
+// the last @.
+func pnpmKeyParts(key string) (name, version string, err error) {
+	key = strings.TrimPrefix(key, "/")
+	key = stripPeerSuffix(key)
+	at := strings.LastIndex(key, "@")
+	if at <= 0 {
+		return "", "", fmt.Errorf("unparseable pnpm package key %q", key)
+	}
+	return key[:at], key[at+1:], nil
+}
+
+// stripPeerSuffix drops the parenthesized peer qualifiers pnpm appends to
+// versions and keys: debug@4.4.3(supports-color@9.0.0) resolves the same
+// package as debug@4.4.3.
+func stripPeerSuffix(s string) string {
+	if i := strings.IndexByte(s, '('); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// importerDeps flattens an importer's dependency table to name → version
+// reference, peer suffixes stripped, link: references kept as they are.
+func importerDeps(raw map[string]rawPnpmImporterDep) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	deps := make(map[string]string, len(raw))
+	for name, dep := range raw {
+		deps[name] = pnpmVersionRef(dep.Version)
+	}
+	return deps
+}
+
+func pnpmVersionRefs(raw map[string]string) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	refs := make(map[string]string, len(raw))
+	for name, version := range raw {
+		refs[name] = pnpmVersionRef(version)
+	}
+	return refs
+}
+
+func pnpmVersionRef(version string) string {
+	if strings.HasPrefix(version, "link:") {
+		return "link:" + path.Clean(strings.TrimPrefix(version, "link:"))
+	}
+	return stripPeerSuffix(version)
+}

--- a/source/npm/pnpmtree.go
+++ b/source/npm/pnpmtree.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package npm
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/protobom/protobom/pkg/sbom"
+
+	api "github.com/carabiner-dev/unpack/api/v1"
+	"github.com/carabiner-dev/unpack/license"
+)
+
+// This file turns a pnpm lock into the dependency graph. Every importer —
+// the project itself and each workspace member — roots the graph with the
+// identity its own package.json states, since the lock keys importers by
+// directory alone. A link: reference is an edge between importers; every
+// other edge resolves into the lock's package table.
+
+type pnpmBuilder struct {
+	lock    *PnpmLock
+	workDir string
+	opts    *api.DecomposerOptions
+
+	nl    *sbom.NodeList
+	nodes map[string]*sbom.Node // package key or importer path → node
+}
+
+func buildPnpmTree(lock *PnpmLock, workDir string, opts *api.DecomposerOptions) (*sbom.NodeList, error) {
+	pb := &pnpmBuilder{
+		lock:    lock,
+		workDir: workDir,
+		opts:    opts,
+		nl:      sbom.NewNodeList(),
+		nodes:   map[string]*sbom.Node{},
+	}
+
+	// The importers in stable order, every one a root. Their nodes exist
+	// before any edges so link: references resolve whichever way they
+	// point.
+	dirs := make([]string, 0, len(lock.Importers))
+	for dir := range lock.Importers {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	for _, dir := range dirs {
+		node, err := pb.importerNode(dir)
+		if err != nil {
+			return nil, err
+		}
+		pb.nodes["importer:"+dir] = node
+		pb.nl.AddRootNode(node)
+	}
+
+	for _, dir := range dirs {
+		if err := pb.importerEdges(dir); err != nil {
+			return nil, err
+		}
+	}
+	return pb.nl, nil
+}
+
+// importerNode builds the root node of one importer from the package.json
+// in its directory.
+func (pb *pnpmBuilder) importerNode(dir string) (*sbom.Node, error) {
+	manifest, err := ParsePackageJSON(filepath.Join(pb.workDir, filepath.FromSlash(dir)))
+	if err != nil {
+		return nil, fmt.Errorf("importer %s: %w", dir, err)
+	}
+
+	name := manifest.Name
+	if name == "" {
+		name = path.Base(dir)
+	}
+	version := manifest.Version
+	if pb.opts.Version != "" {
+		version = pb.opts.Version
+	}
+
+	node := &sbom.Node{
+		Id:      uuid.NewString(),
+		Type:    sbom.Node_PACKAGE,
+		Name:    name,
+		Version: version,
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): buildPURL(name, version),
+		},
+		PrimaryPurpose: []sbom.Purpose{sbom.Purpose_APPLICATION},
+	}
+	if manifest.License != "" {
+		node.Licenses = []string{license.Normalize(manifest.License, "")}
+	}
+	if pb.opts.CommitHash != "" {
+		node.ExternalReferences = append(node.ExternalReferences, &sbom.ExternalReference{
+			Hashes: map[int32]string{int32(sbom.HashAlgorithm_SHA1): pb.opts.CommitHash},
+			Type:   sbom.ExternalReference_VCS,
+		})
+	}
+	return node, nil
+}
+
+// importerEdges adds one importer's direct dependencies, each kind gated by
+// its option, and walks what they pull in.
+func (pb *pnpmBuilder) importerEdges(dir string) error {
+	importer := pb.lock.Importers[dir]
+	parent := pb.nodes["importer:"+dir]
+
+	sections := []struct {
+		deps     map[string]string
+		edgeType sbom.Edge_Type
+		included bool
+	}{
+		{importer.Dependencies, sbom.Edge_dependsOn, true},
+		{importer.DevDependencies, sbom.Edge_devDependency, pb.opts.IncludeDev},
+		{importer.OptionalDependencies, sbom.Edge_optionalDependency, pb.opts.IncludeOptional},
+	}
+	for _, section := range sections {
+		if !section.included {
+			continue
+		}
+		for _, name := range sortedDepNames(section.deps) {
+			if err := pb.addEdge(dir, name, section.deps[name], parent, section.edgeType); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// addEdge resolves one dependency reference and relates it to its parent,
+// walking into it when it is new.
+func (pb *pnpmBuilder) addEdge(importerDir, name, ref string, parent *sbom.Node, edgeType sbom.Edge_Type) error {
+	// A link: points at another importer, relative to this one.
+	if target, isLink := strings.CutPrefix(ref, "link:"); isLink {
+		linked := path.Clean(path.Join(importerDir, target))
+		node, ok := pb.nodes["importer:"+linked]
+		if !ok {
+			return fmt.Errorf("importer %s links to %s, which the lock does not hold", importerDir, linked)
+		}
+		if err := pb.nl.RelateNodeAtID(node, parent.GetId(), edgeType); err != nil {
+			return err
+		}
+		// The linked importer's own edges are added on its own turn.
+		return nil
+	}
+
+	key := name + "@" + ref
+	pkg, ok := pb.lock.Packages[key]
+	if !ok {
+		return fmt.Errorf("the lock has no package for %s", key)
+	}
+
+	node, known := pb.nodes[key]
+	if !known {
+		node = pb.packageNode(pkg)
+		pb.nodes[key] = node
+		pb.nl.AddNode(node)
+	}
+	if err := pb.nl.RelateNodeAtID(node, parent.GetId(), edgeType); err != nil {
+		return err
+	}
+	if known {
+		return nil
+	}
+
+	// The package's own edges: runtime and optional, the latter kept as
+	// information — filtering transitives is the caller's business.
+	for _, dep := range sortedDepNames(pkg.Dependencies) {
+		if err := pb.addEdge(importerDir, dep, pkg.Dependencies[dep], node, sbom.Edge_dependsOn); err != nil {
+			return err
+		}
+	}
+	for _, dep := range sortedDepNames(pkg.OptionalDependencies) {
+		if err := pb.addEdge(importerDir, dep, pkg.OptionalDependencies[dep], node, sbom.Edge_optionalDependency); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// packageNode builds the node of one resolved package.
+func (pb *pnpmBuilder) packageNode(pkg *PnpmPackage) *sbom.Node {
+	node := &sbom.Node{
+		Id:      uuid.NewString(),
+		Type:    sbom.Node_PACKAGE,
+		Name:    pkg.Name,
+		Version: pkg.Version,
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): buildPURL(pkg.Name, pkg.Version),
+		},
+		PrimaryPurpose: []sbom.Purpose{sbom.Purpose_LIBRARY},
+		UrlDownload:    pkg.Tarball,
+	}
+	if algorithm, hash, err := ParseIntegrity(pkg.Integrity); err == nil {
+		if hashAlgo := integrityAlgorithmToSBOM(algorithm); hashAlgo != sbom.HashAlgorithm_UNKNOWN {
+			node.Hashes = map[int32]string{int32(hashAlgo): fmt.Sprintf("%x", hash)}
+		}
+	}
+	return node
+}
+
+func sortedDepNames(deps map[string]string) []string {
+	names := make([]string, 0, len(deps))
+	for name := range deps {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/source/npm/testdata/pnpm/package.json
+++ b/source/npm/testdata/pnpm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "jsdemo",
+  "version": "0.1.0",
+  "dependencies": {
+    "debug": "^4.3.4",
+    "ms": "^2.1.3"
+  },
+  "devDependencies": {
+    "once": "^1.4.0"
+  },
+  "optionalDependencies": {
+    "wrappy": "^1.0.2"
+  }
+}

--- a/source/npm/testdata/pnpm/pnpm-lock.yaml
+++ b/source/npm/testdata/pnpm/pnpm-lock.yaml
@@ -1,0 +1,58 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      debug:
+        specifier: ^4.3.4
+        version: 4.4.3
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
+    devDependencies:
+      once:
+        specifier: ^1.4.0
+        version: 1.4.0
+    optionalDependencies:
+      wrappy:
+        specifier: ^1.0.2
+        version: 1.0.2
+
+packages:
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+snapshots:
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  ms@2.1.3: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  wrappy@1.0.2: {}

--- a/source/npm/testdata/pnpm6/package.json
+++ b/source/npm/testdata/pnpm6/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "jsdemo",
+  "version": "0.1.0",
+  "dependencies": {
+    "debug": "^4.3.4",
+    "ms": "^2.1.3"
+  },
+  "devDependencies": {
+    "once": "^1.4.0"
+  },
+  "optionalDependencies": {
+    "wrappy": "^1.0.2"
+  }
+}

--- a/source/npm/testdata/pnpm6/pnpm-lock.yaml
+++ b/source/npm/testdata/pnpm6/pnpm-lock.yaml
@@ -1,0 +1,50 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  debug:
+    specifier: ^4.3.4
+    version: 4.4.3
+  ms:
+    specifier: ^2.1.3
+    version: 2.1.3
+
+optionalDependencies:
+  wrappy:
+    specifier: ^1.0.2
+    version: 1.0.2
+
+devDependencies:
+  once:
+    specifier: ^1.4.0
+    version: 1.4.0
+
+packages:
+
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: false
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: false
+
+  /once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: true
+
+  /wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/source/npm/testdata/pnpmws/package.json
+++ b/source/npm/testdata/pnpmws/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jsws",
+  "version": "0.1.0",
+  "dependencies": {
+    "ms": "^2.1.3",
+    "liba": "workspace:*"
+  },
+  "devDependencies": {
+    "once": "^1.4.0"
+  }
+}

--- a/source/npm/testdata/pnpmws/packages/liba/package.json
+++ b/source/npm/testdata/pnpmws/packages/liba/package.json
@@ -1,0 +1,1 @@
+{"name": "liba", "version": "0.2.0", "dependencies": {"wrappy": "^1.0.2"}}

--- a/source/npm/testdata/pnpmws/pnpm-lock.yaml
+++ b/source/npm/testdata/pnpmws/pnpm-lock.yaml
@@ -1,0 +1,47 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      liba:
+        specifier: workspace:*
+        version: link:packages/liba
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
+    devDependencies:
+      once:
+        specifier: ^1.4.0
+        version: 1.4.0
+
+  packages/liba:
+    dependencies:
+      wrappy:
+        specifier: ^1.0.2
+        version: 1.0.2
+
+packages:
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+snapshots:
+
+  ms@2.1.3: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  wrappy@1.0.2: {}

--- a/source/npm/testdata/pnpmws/pnpm-workspace.yaml
+++ b/source/npm/testdata/pnpmws/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"


### PR DESCRIPTION
This pull request adds support for parsing and extracting dependency graphs from `pnpm-lock.yaml` files (both schema version 6 and 9) in addition to the existing `package-lock.json` support. It introduces a robust parser and graph builder for pnpm lockfiles, updates codebase discovery to recognize both npm and pnpm lockfiles, and provides thorough tests for pnpm scenarios, including workspaces and dependency types.

**Support for pnpm lockfiles:**

* Added a parser (`pnpmlock.go`) to read and normalize `pnpm-lock.yaml` files (schema v6 and v9), handling importers, packages, and dependency edges.
* Implemented a graph builder (`pnpmtree.go`) to construct SBOM node graphs from pnpm lockfiles, supporting workspaces, link: dependencies, and all dependency types.

**Integration with decomposer:**

* Updated the main decomposer (`decomposer.go`) to detect and extract dependency graphs from both `package-lock.json` and `pnpm-lock.yaml`, preferring npm if both are present. Also improved codebase discovery to recognize both lockfile types and correctly filter out those under `node_modules`. [[1]](diffhunk://#diff-4452c391c96113a2197ad0f92fc807cbd236af5b8d7318db916b43f696f12bdfR8-R10) [[2]](diffhunk://#diff-4452c391c96113a2197ad0f92fc807cbd236af5b8d7318db916b43f696f12bdfR67-R80) [[3]](diffhunk://#diff-4452c391c96113a2197ad0f92fc807cbd236af5b8d7318db916b43f696f12bdfL89-R151)

**Testing enhancements:**

* Added comprehensive tests for pnpm extraction, including schema v6 and v9, dev and optional dependencies, workspaces, and lockfile discovery logic.
* Included test data for pnpm projects and lockfiles in both supported schema versions. [[1]](diffhunk://#diff-03be466fa69761b901a334e1a483e9515a0e25c0330f832ef3ca4aa222b12014R1-R14) [[2]](diffhunk://#diff-cd15c666dd9bc1b49ce8a29b79519e62d054fd8fa77dbbd0200ef43568e75b03R1-R58)

These changes ensure the tool can accurately parse, normalize, and extract dependency information from modern JavaScript projects using either npm or pnpm, improving compatibility and reliability.

**References:** [[1]](diffhunk://#diff-0b9566bf28806cb3be24655ce787c78215b6b172f42a5ee8670b05c24d97466dR1-R230) [[2]](diffhunk://#diff-bf1d95ff7427006982b53dfbe5649d392442eca7e5013d98bb6a6b3878b4136bR1-R216) [[3]](diffhunk://#diff-4452c391c96113a2197ad0f92fc807cbd236af5b8d7318db916b43f696f12bdfR8-R10) [[4]](diffhunk://#diff-4452c391c96113a2197ad0f92fc807cbd236af5b8d7318db916b43f696f12bdfR67-R80) [[5]](diffhunk://#diff-4452c391c96113a2197ad0f92fc807cbd236af5b8d7318db916b43f696f12bdfL89-R151) [[6]](diffhunk://#diff-1dfa6030d6fdc4c38cb530e7fa4bc25d7b790ba988d302e910100095882d982dR1-R153) [[7]](diffhunk://#diff-03be466fa69761b901a334e1a483e9515a0e25c0330f832ef3ca4aa222b12014R1-R14) [[8]](diffhunk://#diff-cd15c666dd9bc1b49ce8a29b79519e62d054fd8fa77dbbd0200ef43568e75b03R1-R58)